### PR TITLE
Add `haskell-language-server` to tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1139,11 +1139,11 @@
     },
     "nixpkgs-2009": {
       "locked": {
-        "lastModified": 1624271064,
-        "narHash": "sha256-qns/uRW7MR2EfVf6VEeLgCsCp7pIOjDeR44JzTF09MA=",
+        "lastModified": 1635350005,
+        "narHash": "sha256-tAMJnUwfaDEB2aa31jGcu7R7bzGELM9noc91L2PbVjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46d1c3f28ca991601a53e9a14fdd53fcd3dd8416",
+        "rev": "1c1f5649bb9c1b0d98637c8c365228f57126f361",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -321,12 +321,9 @@
               graphviz
             ];
 
-            additional = ps: [
-              ps.plutarch
-              ps.plutus-ledger
-              ps.plutus-extra
+            additional = ps: [ ps.plutarch ps.plutus-ledger ps.plutus-extra ];
 
-            ];
+            tools.haskell-language-server = { };
           };
         };
     in {


### PR DESCRIPTION
Closes #21. This seems to be enough for our purposes. Especially since we are only using 8.10.7 for now. Can you test that this works for you, @jhodgdev?