### PR TITLE
Treasury Withdrawal Effect

### DIFF
--- a/agora.cabal
+++ b/agora.cabal
@@ -129,6 +129,7 @@ library
     Agora.Treasury
     Agora.Governor
     Agora.Proposal
+    Agora.Effect.TreasuryWithdrawal
 
   other-modules:
     Agora.Utils

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -3,25 +3,31 @@ Module     : Agora.Effect.TreasuryWithdrawal
 Maintainer : seungheon.ooh@gmail.com
 Description: An Effect that withdraws treasury deposit
 -}
-module Agora.Effect.TreasuryWithdrawal (treasuryWithdrawalDatum) where
+module Agora.Effect.TreasuryWithdrawal (PTreasuryWithdrawalDatum, treasuryWithdrawalValidator) where
 
 import GHC.Generics qualified as GHC
-import Generics.SOP
+import Generics.SOP (Generic, I (I))
 
-import Agora.Effect
-import Agora.Utils
-import Plutus.V1.Ledger.Value
-import Plutarch
-import qualified Plutarch.Monadic as P
-import Plutarch.Api.V1
-import Plutarch.DataRepr
+import Agora.Effect (makeEffect)
+import Agora.Utils (passert)
+import Plutarch (popaque)
+import Plutarch.Api.V1 (
+  PCredential,
+  PTuple,
+  PValidator,
+  PValue,
+  ptuple,
+ )
+import Plutarch.DataRepr (PDataFields, PIsDataReprInstances (..))
+import Plutarch.Monadic qualified as P
+import Plutus.V1.Ledger.Value (CurrencySymbol)
 
 data PTreasuryWithdrawalDatum (s :: S)
   = PTreasuryWithdrawalDatum
       ( Term
           s
-          (PDataRecord
-           '[ "receivers" ':= PBuiltinList (PAsData (PTuple PCredential PValue)) ]
+          ( PDataRecord
+              '["receivers" ':= PBuiltinList (PAsData (PTuple PCredential PValue))]
           )
       )
   deriving stock (GHC.Generic)
@@ -30,22 +36,26 @@ data PTreasuryWithdrawalDatum (s :: S)
     (PlutusType, PIsData, PDataFields)
     via PIsDataReprInstances PTreasuryWithdrawalDatum
 
-treasuryWithdrawalDatum :: forall {s :: S}. CurrencySymbol -> Term s PValidator
-treasuryWithdrawalDatum currSymbol = makeEffect currSymbol $
+treasuryWithdrawalValidator :: forall {s :: S}. CurrencySymbol -> Term s PValidator
+treasuryWithdrawalValidator currSymbol = makeEffect currSymbol $
   \_cs (_datum :: Term _ PTreasuryWithdrawalDatum) _txOutRef _txInfo -> P.do
-  let outputs = pmap #
-                plam (\_out -> P.do
-                       out <- pletFields @'["address", "value"] $ pfromData _out
-                       cred <- pletFields @'["credential"] $ pfromData out.address
-                       pdata $ ptuple # cred.credential # out.value
-                     ) #$
-                pfield @"outputs" # _txInfo
-      recivers = pfromData (pfield @"receivers" # _datum)
-      checkOutputs = pall # plam id #$ pmap #
-                     plam (\_out -> P.do
-                            pelem # _out # outputs
-                          ) #$
-                     recivers
-  passert "Transaction output does not match receivers" checkOutputs
-  popaque $ pconstant ()
-
+    let outputs =
+          pmap
+            # plam
+              ( \_out -> P.do
+                  out <- pletFields @'["address", "value"] $ pfromData _out
+                  cred <- pletFields @'["credential"] $ pfromData out.address
+                  pdata $ ptuple # cred.credential # out.value
+              )
+            #$ pfield @"outputs"
+            # _txInfo
+        recivers = pfromData $ pfield @"receivers" # _datum
+        checkOutputs =
+          pall # plam id #$ pmap
+            # plam
+              ( \_out -> P.do
+                  pelem # _out # outputs
+              )
+            #$ recivers
+    passert "Transaction output does not match receivers" checkOutputs
+    popaque $ pconstant ()

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -1,12 +1,14 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 {- |
 Module     : Agora.Effect.TreasuryWithdrawal
 Maintainer : seungheon.ooh@gmail.com
 Description: An Effect that withdraws treasury deposit
 -}
-module Agora.Effect.TreasuryWithdrawal (PTreasuryWithdrawalDatum, treasuryWithdrawalValidator) where
+module Agora.Effect.TreasuryWithdrawal (TreasuryWithdrawalDatum, PTreasuryWithdrawalDatum, treasuryWithdrawalValidator) where
 
 import GHC.Generics qualified as GHC
-import Generics.SOP (Generic, I (I))
+import Generics.SOP ( I(I), Generic )
 
 import Agora.Effect (makeEffect)
 import Agora.Utils (passert)
@@ -18,9 +20,22 @@ import Plutarch.Api.V1 (
   PValue,
   ptuple,
  )
-import Plutarch.DataRepr (PDataFields, PIsDataReprInstances (..))
+import Plutarch.DataRepr
+    ( PDataFields,
+      PIsDataReprInstances(..),
+      DerivePConstantViaData(..) )
+import Plutarch.Lift ( PUnsafeLiftDecl(..) )
 import Plutarch.Monadic qualified as P
-import Plutus.V1.Ledger.Value (CurrencySymbol)
+import Plutus.V1.Ledger.Credential ( Credential )
+import Plutus.V1.Ledger.Value ( CurrencySymbol, Value )
+import PlutusTx qualified
+
+data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum {receivers :: [(Credential, Value)]}
+  deriving stock (Show, GHC.Generic)
+  deriving anyclass (Generic)
+
+PlutusTx.makeLift ''TreasuryWithdrawalDatum
+PlutusTx.unstableMakeIsData ''TreasuryWithdrawalDatum
 
 data PTreasuryWithdrawalDatum (s :: S)
   = PTreasuryWithdrawalDatum
@@ -36,10 +51,19 @@ data PTreasuryWithdrawalDatum (s :: S)
     (PlutusType, PIsData, PDataFields)
     via PIsDataReprInstances PTreasuryWithdrawalDatum
 
+instance PUnsafeLiftDecl PTreasuryWithdrawalDatum where
+  type PLifted PTreasuryWithdrawalDatum = TreasuryWithdrawalDatum
+deriving via
+  (DerivePConstantViaData TreasuryWithdrawalDatum PTreasuryWithdrawalDatum)
+  instance
+    (PConstant TreasuryWithdrawalDatum)
+
 treasuryWithdrawalValidator :: forall {s :: S}. CurrencySymbol -> Term s PValidator
 treasuryWithdrawalValidator currSymbol = makeEffect currSymbol $
   \_cs (_datum :: Term _ PTreasuryWithdrawalDatum) _txOutRef _txInfo -> P.do
-    let outputs =
+    receivers <- plet $ pfromData $ pfield @"receivers" # _datum
+    txInfo <- pletFields @'["outputs"] _txInfo
+    let outputValues =
           pmap
             # plam
               ( \_out -> P.do
@@ -47,15 +71,17 @@ treasuryWithdrawalValidator currSymbol = makeEffect currSymbol $
                   cred <- pletFields @'["credential"] $ pfromData out.address
                   pdata $ ptuple # cred.credential # out.value
               )
-            #$ pfield @"outputs"
-            # _txInfo
-        recivers = pfromData $ pfield @"receivers" # _datum
-        checkOutputs =
+            #$ txInfo.outputs
+        outputContentMatchesRecivers =
           pall # plam id #$ pmap
-            # plam
-              ( \_out -> P.do
-                  pelem # _out # outputs
-              )
-            #$ recivers
-    passert "Transaction output does not match receivers" checkOutputs
+            # plam (\_out -> pelem # _out # outputValues)
+            #$ receivers
+        outputNumberMatchesRecivers = plength # receivers #== plength # (pfromData txInfo.outputs)
+        outputIsNotPayingToEffect = pconstant True -- How to check if it's not paying to effect itself?
+
+    passert "Transaction output does not match receivers"
+      $     outputContentMatchesRecivers
+        #&& outputNumberMatchesRecivers
+        #&& outputIsNotPayingToEffect
+
     popaque $ pconstant ()

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -1,0 +1,51 @@
+{- |
+Module     : Agora.Effect.TreasuryWithdrawal
+Maintainer : seungheon.ooh@gmail.com
+Description: An Effect that withdraws treasury deposit
+-}
+module Agora.Effect.TreasuryWithdrawal (treasuryWithdrawalDatum) where
+
+import GHC.Generics qualified as GHC
+import Generics.SOP
+
+import Agora.Effect
+import Agora.Utils
+import Plutus.V1.Ledger.Value
+import Plutarch
+import qualified Plutarch.Monadic as P
+import Plutarch.Api.V1
+import Plutarch.DataRepr
+
+data PTreasuryWithdrawalDatum (s :: S)
+  = PTreasuryWithdrawalDatum
+      ( Term
+          s
+          (PDataRecord
+           '[ "receivers" ':= PBuiltinList (PAsData (PTuple PCredential PValue)) ]
+          )
+      )
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic, PIsDataRepr)
+  deriving
+    (PlutusType, PIsData, PDataFields)
+    via PIsDataReprInstances PTreasuryWithdrawalDatum
+
+treasuryWithdrawalDatum :: forall {s :: S}. CurrencySymbol -> Term s PValidator
+treasuryWithdrawalDatum currSymbol = makeEffect currSymbol $
+  \_cs (_datum :: Term _ PTreasuryWithdrawalDatum) _txOutRef _txInfo -> P.do
+  let outputs = pmap #
+                plam (\_out -> P.do
+                       out <- pletFields @'["address", "value"] $ pfromData _out
+                       cred <- pletFields @'["credential"] $ pfromData out.address
+                       pdata $ ptuple # cred.credential # out.value
+                     ) #$
+                pfield @"outputs" # _txInfo
+      recivers = pfromData (pfield @"receivers" # _datum)
+      checkOutputs = pall # plam id #$ pmap #
+                     plam (\_out -> P.do
+                            pelem # _out # outputs
+                          ) #$
+                     recivers
+  passert "Transaction output does not match receivers" checkOutputs
+  popaque $ pconstant ()
+


### PR DESCRIPTION
Currently this effect checks 
- if outputs matches the given list of receivers and corresponding value
- if number of total transaction matches to that of given datum
- if anything is paying to the effect itself. 
- if input is exactly minAda

Later, 
- [ ] it can replace some functions with utility functions added in connor/governor. 
- [ ] I'm not sure if I want to add a part checking if minAda is paid back correctly; I think its already covered.