### PR TITLE
Fix CI format checks

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Extensions necessary to tell fourmolu about
-EXTENSIONS="-o -XTypeApplications -o -XTemplateHaskell -o -XImportQualifiedPost -o -XPatternSynonyms -o -XOverloadedRecordDot"
-SOURCES=$(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
-nix run nixpkgs#haskell.packages.ghc921.fourmolu -- --mode check --check-idempotence $EXTENSIONS $SOURCES

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -34,30 +34,8 @@ jobs:
           name: mlabs
           authToken: ${{ secrets.CACHIX_KEY }}
 
-      - run: ./.github/format.sh
-        name: Run fourmolu
-
-  run-linter:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.4.0
-
-      - uses: cachix/install-nix-action@v16
-        name: Set up Nix and IOHK caches
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
-            experimental-features = nix-command flakes
-
-      - uses: cachix/cachix-action@v10
-        with:
-          name: mlabs
-          authToken: ${{ secrets.CACHIX_KEY }}
-
-      - run: nix run nixpkgs#haskell.packages.ghc921.hlint -- $(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
-        name: Run hlint
+      - run: nix build .#checks.x86_64-linux.formatCheck
+        name: Run 'formatCheck' from flake.nix
 
   check-build:
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
             pkgs'.haskellPackages.cabal-fmt
             pkgs'.nixpkgs-fmt
             fourmolu
-            plutarch.tools.hlint
+            pkgs'.haskell.packages."${ghcVersion}".hlint
           ];
         } ''
           export LC_CTYPE=C.UTF-8

--- a/flake.nix
+++ b/flake.nix
@@ -115,15 +115,19 @@
         let
           pkgs = nixpkgsFor system;
           pkgs' = nixpkgsFor' system;
+
+          inherit (pkgs.haskell-nix.tools ghcVersion {
+            inherit (plutarch.tools) fourmolu;
+          })
+            fourmolu;
         in pkgs.runCommand "format-check" {
           nativeBuildInputs = [
             pkgs'.git
             pkgs'.fd
             pkgs'.haskellPackages.cabal-fmt
             pkgs'.nixpkgs-fmt
-            (pkgs.haskell-nix.tools ghcVersion {
-              inherit (plutarch.tools) fourmolu;
-            }).fourmolu
+            fourmolu
+            plutarch.tools.hlint
           ];
         } ''
           export LC_CTYPE=C.UTF-8
@@ -131,6 +135,7 @@
           export LANG=C.UTF-8
           cd ${self}
           make format_check || (echo "    Please run 'make format'" ; exit 1)
+          find -name '*.hs' -not -path './dist*/*' -not -path './haddock/*' | xargs hlint
           mkdir $out
         '';
     in {


### PR DESCRIPTION
Fixes CI format checks. They previously died due to `nixpkgs` changing from underneath us and `ghc921` being no longer under `nixpkgs.haskell.packages`. Now we use consistently only what the flake uses.