### PR TITLE
Proposal validator implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,7 @@ format_check:
 
 haddock:
 	cabal haddock --haddock-html --haddock-hoogle --builddir=haddock
+
+tag:
+	hasktags -x agora agora-bench agora-test
+

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ usage:
 	@echo "  hoogle -- Start local hoogle"
 	@echo "  format -- Format the project"
 	@echo "  haddock -- Generate Haddock docs for project"
+	@echo "  tag -- Generate CTAGS and ETAGS files for project"
 
 hoogle:
 	pkill hoogle || true

--- a/agora-test/Spec.hs
+++ b/agora-test/Spec.hs
@@ -11,6 +11,7 @@ import Test.Tasty (defaultMain, testGroup)
 import Spec.AuthorityToken qualified as AuthorityToken
 import Spec.Effect.TreasuryWithdrawal qualified as TreasuryWithdrawal
 import Spec.Model.MultiSig qualified as MultiSig
+import Spec.Proposal qualified as Proposal
 import Spec.Stake qualified as Stake
 
 -- | The Agora test suite.
@@ -28,6 +29,9 @@ main =
       , testGroup
           "Stake tests"
           Stake.tests
+      , testGroup
+          "Proposal tests"
+          Proposal.tests
       , testGroup
           "Multisig tests"
           [ testGroup

--- a/agora-test/Spec/Effect/TreasuryWithdrawal.hs
+++ b/agora-test/Spec/Effect/TreasuryWithdrawal.hs
@@ -7,6 +7,11 @@ This module tests the Treasury Withdrawal Effect.
 -}
 module Spec.Effect.TreasuryWithdrawal (tests) where
 
+import Agora.Effect.TreasuryWithdrawal (
+  TreasuryWithdrawalDatum (TreasuryWithdrawalDatum),
+  treasuryWithdrawalValidator,
+ )
+import Plutus.V1.Ledger.Value qualified as Value
 import Spec.Sample.Effect.TreasuryWithdrawal (
   buildReceiversOutputFromDatum,
   buildScriptContext,
@@ -20,15 +25,7 @@ import Spec.Sample.Effect.TreasuryWithdrawal (
   treasuries,
   users,
  )
-
-import Agora.Effect.TreasuryWithdrawal (
-  TreasuryWithdrawalDatum (TreasuryWithdrawalDatum),
-  treasuryWithdrawalValidator,
- )
-
-import Plutus.V1.Ledger.Value qualified as Value
 import Spec.Util (effectFailsWith, effectSucceedsWith)
-
 import Test.Tasty (TestTree, testGroup)
 
 tests :: [TestTree]

--- a/agora-test/Spec/Proposal.hs
+++ b/agora-test/Spec/Proposal.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+{- |
+Module     : Spec.Proposal
+Maintainer : emi@haskell.fyi
+Description: Tests for Proposal policy and validator
+
+Tests for Proposal policy and validator
+-}
+module Spec.Proposal (tests) where
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+
+import Agora.Proposal (proposalPolicy)
+import Spec.Sample.Proposal qualified as Proposal
+import Spec.Util (policySucceedsWith)
+import Test.Tasty (TestTree, testGroup)
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+
+-- | Stake tests.
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "policy"
+      [ policySucceedsWith
+          "stakeCreation"
+          (proposalPolicy Proposal.proposal)
+          ()
+          Proposal.proposalCreation
+      ]
+  ]

--- a/agora-test/Spec/Proposal.hs
+++ b/agora-test/Spec/Proposal.hs
@@ -13,9 +13,26 @@ module Spec.Proposal (tests) where
 
 --------------------------------------------------------------------------------
 
-import Agora.Proposal (proposalPolicy)
+import Agora.Proposal (
+  ProposalDatum (ProposalDatum),
+  ProposalId (ProposalId),
+  ProposalRedeemer (Cosign),
+  ProposalStatus (Draft),
+  ProposalVotes (ProposalVotes),
+  ResultTag (ResultTag),
+  cosigners,
+  effects,
+  proposalId,
+  proposalPolicy,
+  proposalValidator,
+  status,
+  thresholds,
+  votes,
+ )
+import PlutusTx.AssocMap qualified as AssocMap
+import Spec.Sample.Proposal (propThresholds, signer, signer2)
 import Spec.Sample.Proposal qualified as Proposal
-import Spec.Util (policySucceedsWith)
+import Spec.Util (policySucceedsWith, validatorSucceedsWith)
 import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
@@ -34,5 +51,26 @@ tests =
           (proposalPolicy Proposal.proposal)
           ()
           Proposal.proposalCreation
+      ]
+  , testGroup
+      "validator"
+      [ validatorSucceedsWith
+          "stakeCreation"
+          (proposalValidator Proposal.proposal)
+          ( ProposalDatum
+              { proposalId = ProposalId 0
+              , effects =
+                  AssocMap.fromList
+                    [ (ResultTag 0, [])
+                    , (ResultTag 1, [])
+                    ]
+              , status = Draft
+              , cosigners = [signer]
+              , thresholds = propThresholds
+              , votes = ProposalVotes AssocMap.empty
+              }
+          )
+          (Cosign [signer2])
+          (Proposal.cosignProposal [signer2])
       ]
   ]

--- a/agora-test/Spec/Proposal.hs
+++ b/agora-test/Spec/Proposal.hs
@@ -21,13 +21,16 @@ import Agora.Proposal (
   cosigners,
   effects,
   proposalId,
-  proposalPolicy,
-  proposalValidator,
   status,
   thresholds,
   votes,
  )
-import Agora.Stake (StakeDatum (StakeDatum), StakeRedeemer (WitnessStake), stakeValidator)
+import Agora.Proposal.Scripts (
+  proposalPolicy,
+  proposalValidator,
+ )
+import Agora.Stake (StakeDatum (StakeDatum), StakeRedeemer (WitnessStake))
+import Agora.Stake.Scripts (stakeValidator)
 import Plutarch.SafeMoney (Tagged (Tagged))
 import Plutus.V1.Ledger.Api (ScriptContext (..), ScriptPurpose (..))
 import PlutusTx.AssocMap qualified as AssocMap
@@ -36,10 +39,6 @@ import Spec.Sample.Shared (signer, signer2)
 import Spec.Sample.Shared qualified as Shared
 import Spec.Util (policySucceedsWith, validatorSucceedsWith)
 import Test.Tasty (TestTree, testGroup)
-
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
 

--- a/agora-test/Spec/Proposal.hs
+++ b/agora-test/Spec/Proposal.hs
@@ -16,10 +16,10 @@ import Agora.Proposal (
   ProposalId (ProposalId),
   ProposalRedeemer (Cosign),
   ProposalStatus (Draft),
-  ProposalVotes (ProposalVotes),
   ResultTag (ResultTag),
   cosigners,
   effects,
+  emptyVotesFor,
   proposalId,
   status,
   thresholds,
@@ -70,7 +70,12 @@ tests =
                   , status = Draft
                   , cosigners = [signer]
                   , thresholds = Shared.defaultProposalThresholds
-                  , votes = ProposalVotes AssocMap.empty
+                  , votes =
+                      emptyVotesFor $
+                        AssocMap.fromList
+                          [ (ResultTag 0, [])
+                          , (ResultTag 1, [])
+                          ]
                   }
               )
               (Cosign [signer2])

--- a/agora-test/Spec/Sample/Proposal.hs
+++ b/agora-test/Spec/Sample/Proposal.hs
@@ -1,0 +1,198 @@
+{- |
+Module     : Spec.Sample.Proposal
+Maintainer : emi@haskell.fyi
+Description: Sample based testing for Proposal utxos
+
+This module tests primarily the happy path for Proposal interactions
+-}
+module Spec.Sample.Proposal (
+  proposal,
+  policy,
+  policySymbol,
+  validatorHashTN,
+  signer,
+
+  -- * Script contexts
+  proposalCreation,
+) where
+
+--------------------------------------------------------------------------------
+import Plutarch.Api.V1 (
+  mintingPolicySymbol,
+  mkMintingPolicy,
+  mkValidator,
+  validatorHash,
+ )
+import Plutus.V1.Ledger.Api (
+  Address (Address),
+  Credential (ScriptCredential),
+  CurrencySymbol,
+  Datum (Datum),
+  MintingPolicy (..),
+  PubKeyHash,
+  ScriptContext (..),
+  ScriptPurpose (..),
+  ToData (toBuiltinData),
+  TxInInfo (TxInInfo),
+  TxInfo (..),
+  TxOut (TxOut, txOutAddress, txOutDatumHash, txOutValue),
+  TxOutRef (TxOutRef),
+  ValidatorHash (ValidatorHash),
+ )
+import Plutus.V1.Ledger.Interval qualified as Interval
+import Plutus.V1.Ledger.Scripts (Validator)
+import Plutus.V1.Ledger.Value (AssetClass (AssetClass), TokenName (TokenName))
+import Plutus.V1.Ledger.Value qualified as Value
+
+--------------------------------------------------------------------------------
+
+import Agora.Governor (
+  Governor (Governor),
+  GovernorDatum (GovernorDatum, nextProposalId, proposalThresholds),
+  governorPolicy,
+  governorValidator,
+ )
+import Agora.Proposal
+import Plutarch.SafeMoney
+import PlutusTx.AssocMap qualified as AssocMap
+import Spec.Util (datumPair, toDatumHash)
+
+--------------------------------------------------------------------------------
+
+governor :: Governor
+governor = Governor
+
+govPolicy :: MintingPolicy
+govPolicy = mkMintingPolicy (governorPolicy governor)
+
+govValidator :: Validator
+govValidator = mkValidator (governorValidator governor)
+
+govSymbol :: CurrencySymbol
+govSymbol = mintingPolicySymbol govPolicy
+
+proposal :: Proposal
+proposal =
+  Proposal
+    { governorSTAssetClass =
+        -- TODO: if we had a governor here
+        AssetClass
+          ( govSymbol
+          , ""
+          )
+    }
+
+-- | 'Proposal' policy instance.
+policy :: MintingPolicy
+policy = mkMintingPolicy (proposalPolicy proposal)
+
+policySymbol :: CurrencySymbol
+policySymbol = mintingPolicySymbol policy
+
+-- | A sample 'PubKeyHash'.
+signer :: PubKeyHash
+signer = "8a30896c4fd5e79843e4ca1bd2cdbaa36f8c0bc3be7401214142019c"
+
+-- | 'Proposal' validator instance.
+validator :: Validator
+validator = mkValidator (proposalValidator proposal)
+
+-- | 'TokenName' that represents the hash of the 'Proposal' validator.
+validatorHashTN :: TokenName
+validatorHashTN = let ValidatorHash vh = validatorHash validator in TokenName vh
+
+propThresholds :: ProposalThresholds
+propThresholds =
+  ProposalThresholds
+    { countVoting = Tagged 1000
+    , create = Tagged 1
+    , vote = Tagged 10
+    }
+
+-- | This script context should be a valid transaction.
+proposalCreation :: ScriptContext
+proposalCreation =
+  let st = Value.singleton policySymbol "" 1 -- Proposal ST
+      proposalDatum :: Datum
+      proposalDatum =
+        Datum
+          ( toBuiltinData $
+              ProposalDatum
+                { proposalId = ProposalId 0
+                , effects =
+                    AssocMap.fromList
+                      [ (ResultTag 0, [])
+                      , (ResultTag 1, [])
+                      ]
+                , status = Draft
+                , cosigners = [signer]
+                , thresholds = propThresholds
+                , votes = ProposalVotes $ AssocMap.empty
+                }
+          )
+
+      govBefore :: Datum
+      govBefore =
+        Datum
+          ( toBuiltinData $
+              GovernorDatum
+                { proposalThresholds = propThresholds
+                , nextProposalId = ProposalId 0
+                }
+          )
+      govAfter :: Datum
+      govAfter =
+        Datum
+          ( toBuiltinData $
+              GovernorDatum
+                { proposalThresholds = propThresholds
+                , nextProposalId = ProposalId 1
+                }
+          )
+   in ScriptContext
+        { scriptContextTxInfo =
+            TxInfo
+              { txInfoInputs =
+                  [ TxInInfo
+                      (TxOutRef "0b2086cbf8b6900f8cb65e012de4516cb66b5cb08a9aaba12a8b88be" 1)
+                      TxOut
+                        { txOutAddress = Address (ScriptCredential $ validatorHash validator) Nothing
+                        , txOutValue = Value.assetClassValue proposal.governorSTAssetClass 1
+                        , txOutDatumHash = Just (toDatumHash govBefore)
+                        }
+                  ]
+              , txInfoOutputs =
+                  [ TxOut
+                      { txOutAddress = Address (ScriptCredential $ validatorHash validator) Nothing
+                      , txOutValue =
+                          mconcat
+                            [ st
+                            , Value.singleton "" "" 10_000_000
+                            ]
+                      , txOutDatumHash = Just (toDatumHash proposalDatum)
+                      }
+                  , TxOut
+                      { txOutAddress = Address (ScriptCredential $ validatorHash govValidator) Nothing
+                      , txOutValue =
+                          mconcat
+                            [ Value.assetClassValue proposal.governorSTAssetClass 1
+                            , Value.singleton "" "" 10_000_000
+                            ]
+                      , txOutDatumHash = Just (toDatumHash govAfter)
+                      }
+                  ]
+              , txInfoFee = Value.singleton "" "" 2
+              , txInfoMint = st
+              , txInfoDCert = []
+              , txInfoWdrl = []
+              , txInfoValidRange = Interval.always
+              , txInfoSignatories = [signer]
+              , txInfoData =
+                  [ datumPair proposalDatum
+                  , datumPair govBefore
+                  , datumPair govAfter
+                  ]
+              , txInfoId = "0b2086cbf8b6900f8cb65e012de4516cb66b5cb08a9aaba12a8b88be"
+              }
+        , scriptContextPurpose = Minting policySymbol
+        }

--- a/agora-test/Spec/Sample/Proposal.hs
+++ b/agora-test/Spec/Sample/Proposal.hs
@@ -127,7 +127,7 @@ proposalCreation =
                 , status = Draft
                 , cosigners = [signer]
                 , thresholds = propThresholds
-                , votes = ProposalVotes $ AssocMap.empty
+                , votes = ProposalVotes AssocMap.empty
                 }
           )
 
@@ -156,7 +156,7 @@ proposalCreation =
                   [ TxInInfo
                       (TxOutRef "0b2086cbf8b6900f8cb65e012de4516cb66b5cb08a9aaba12a8b88be" 1)
                       TxOut
-                        { txOutAddress = Address (ScriptCredential $ validatorHash validator) Nothing
+                        { txOutAddress = Address (ScriptCredential $ validatorHash govValidator) Nothing
                         , txOutValue = Value.assetClassValue proposal.governorSTAssetClass 1
                         , txOutDatumHash = Just (toDatumHash govBefore)
                         }

--- a/agora-test/Spec/Sample/Proposal.hs
+++ b/agora-test/Spec/Sample/Proposal.hs
@@ -43,7 +43,6 @@ import Agora.Proposal (
   ProposalDatum (..),
   ProposalId (..),
   ProposalStatus (..),
-  ProposalVotes (..),
   ResultTag (..),
   emptyVotesFor,
  )

--- a/agora-test/Spec/Sample/Proposal.hs
+++ b/agora-test/Spec/Sample/Proposal.hs
@@ -45,6 +45,7 @@ import Agora.Proposal (
   ProposalStatus (..),
   ProposalVotes (..),
   ResultTag (..),
+  emptyVotesFor,
  )
 import Agora.Stake (Stake (..), StakeDatum (StakeDatum))
 import Plutarch.SafeMoney (Tagged (Tagged), untag)
@@ -58,21 +59,22 @@ import Spec.Util (datumPair, toDatumHash)
 proposalCreation :: ScriptContext
 proposalCreation =
   let st = Value.singleton proposalPolicySymbol "" 1 -- Proposal ST
+      effects =
+        AssocMap.fromList
+          [ (ResultTag 0, [])
+          , (ResultTag 1, [])
+          ]
       proposalDatum :: Datum
       proposalDatum =
         Datum
           ( toBuiltinData $
               ProposalDatum
                 { proposalId = ProposalId 0
-                , effects =
-                    AssocMap.fromList
-                      [ (ResultTag 0, [])
-                      , (ResultTag 1, [])
-                      ]
+                , effects = effects
                 , status = Draft
                 , cosigners = [signer]
                 , thresholds = defaultProposalThresholds
-                , votes = ProposalVotes AssocMap.empty
+                , votes = emptyVotesFor effects
                 }
           )
 

--- a/agora-test/Spec/Sample/Proposal.hs
+++ b/agora-test/Spec/Sample/Proposal.hs
@@ -154,19 +154,20 @@ stakeRef = TxOutRef "0ca36f3a357bc69579ab2531aecd1e7d3714d993c7820f40b864be15" 0
 cosignProposal :: [PubKeyHash] -> TxInfo
 cosignProposal newSigners =
   let st = Value.singleton proposalPolicySymbol "" 1 -- Proposal ST
+      effects =
+        AssocMap.fromList
+          [ (ResultTag 0, [])
+          , (ResultTag 1, [])
+          ]
       proposalBefore :: ProposalDatum
       proposalBefore =
         ProposalDatum
           { proposalId = ProposalId 0
-          , effects =
-              AssocMap.fromList
-                [ (ResultTag 0, [])
-                , (ResultTag 1, [])
-                ]
+          , effects = effects
           , status = Draft
           , cosigners = [signer]
           , thresholds = defaultProposalThresholds
-          , votes = ProposalVotes AssocMap.empty
+          , votes = emptyVotesFor effects
           }
       stakeDatum :: StakeDatum
       stakeDatum = StakeDatum (Tagged 50_000_000) signer2 []

--- a/agora-test/Spec/Sample/Shared.hs
+++ b/agora-test/Spec/Sample/Shared.hs
@@ -1,0 +1,132 @@
+{- |
+Module     : Spec.Sample.Shared
+Maintainer : emi@haskell.fyi
+Description: Shared useful values for creating Samples for testing.
+
+Shared useful values for creating Samples for testing.
+-}
+module Spec.Sample.Shared (
+  -- * Misc
+  signer,
+  signer2,
+
+  -- * Components
+
+  -- ** Stake
+  stake,
+  stakeSymbol,
+  stakeValidatorHash,
+  stakeAddress,
+
+  -- ** Governor
+  governor,
+  govPolicy,
+  govValidator,
+  govSymbol,
+
+  -- ** Proposal
+  defaultProposalThresholds,
+  proposal,
+  proposalPolicySymbol,
+  proposalValidatorHash,
+  proposalValidatorAddress,
+) where
+
+import Agora.Governor (
+  Governor (Governor),
+  governorPolicy,
+  governorValidator,
+ )
+import Agora.Proposal (
+  Proposal (..),
+  ProposalThresholds (..),
+  proposalPolicy,
+  proposalValidator,
+ )
+import Agora.Stake (Stake (..), stakePolicy, stakeValidator)
+import Plutarch.Api.V1 (
+  mintingPolicySymbol,
+  mkMintingPolicy,
+  mkValidator,
+  validatorHash,
+ )
+import Plutarch.SafeMoney
+import Plutus.V1.Ledger.Address (scriptHashAddress)
+import Plutus.V1.Ledger.Api (
+  Address (Address),
+  Credential (ScriptCredential),
+  CurrencySymbol,
+  MintingPolicy (..),
+  PubKeyHash,
+ )
+import Plutus.V1.Ledger.Scripts (Validator, ValidatorHash)
+import Plutus.V1.Ledger.Value qualified as Value
+
+--------------------------------------------------------------------------------
+
+stake :: Stake
+stake =
+  Stake
+    { gtClassRef =
+        Tagged $
+          Value.assetClass
+            "da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24"
+            "LQ"
+    , proposalSTClass = Value.assetClass proposalPolicySymbol ""
+    }
+
+stakeSymbol :: CurrencySymbol
+stakeSymbol = mintingPolicySymbol $ mkMintingPolicy $ stakePolicy stake.gtClassRef
+
+stakeValidatorHash :: ValidatorHash
+stakeValidatorHash = validatorHash $ mkValidator (stakeValidator stake)
+
+stakeAddress :: Address
+stakeAddress = Address (ScriptCredential stakeValidatorHash) Nothing
+
+governor :: Governor
+governor = Governor
+
+govPolicy :: MintingPolicy
+govPolicy = mkMintingPolicy (governorPolicy governor)
+
+govValidator :: Validator
+govValidator = mkValidator (governorValidator governor)
+
+govSymbol :: CurrencySymbol
+govSymbol = mintingPolicySymbol govPolicy
+
+proposal :: Proposal
+proposal =
+  Proposal
+    { governorSTAssetClass =
+        -- TODO: if we had a governor here
+        Value.assetClass govSymbol ""
+    , stakeSTAssetClass =
+        Value.assetClass stakeSymbol ""
+    }
+
+proposalPolicySymbol :: CurrencySymbol
+proposalPolicySymbol = mintingPolicySymbol $ mkMintingPolicy (proposalPolicy proposal)
+
+-- | A sample 'PubKeyHash'.
+signer :: PubKeyHash
+signer = "8a30896c4fd5e79843e4ca1bd2cdbaa36f8c0bc3be7401214142019c"
+
+-- | Another sample 'PubKeyHash'.
+signer2 :: PubKeyHash
+signer2 = "8a30896c4fd5e79843e4ca1bd2cdbaa36f8c0bc3be74012141420192"
+
+proposalValidatorHash :: ValidatorHash
+proposalValidatorHash = validatorHash (mkValidator $ proposalValidator proposal)
+
+proposalValidatorAddress :: Address
+proposalValidatorAddress = scriptHashAddress proposalValidatorHash
+
+defaultProposalThresholds :: ProposalThresholds
+defaultProposalThresholds =
+  ProposalThresholds
+    { countVoting = Tagged 1000
+    , create = Tagged 1
+    , vote = Tagged 10
+    }

--- a/agora-test/Spec/Sample/Shared.hs
+++ b/agora-test/Spec/Sample/Shared.hs
@@ -129,5 +129,5 @@ defaultProposalThresholds =
   ProposalThresholds
     { countVoting = Tagged 1000
     , create = Tagged 1
-    , vote = Tagged 10
+    , startVoting = Tagged 10
     }

--- a/agora-test/Spec/Sample/Shared.hs
+++ b/agora-test/Spec/Sample/Shared.hs
@@ -107,6 +107,7 @@ proposal =
         Value.assetClass govSymbol ""
     , stakeSTAssetClass =
         Value.assetClass stakeSymbol ""
+    , maximumCosigners = 6
     }
 
 proposalPolicySymbol :: CurrencySymbol

--- a/agora-test/Spec/Sample/Shared.hs
+++ b/agora-test/Spec/Sample/Shared.hs
@@ -40,10 +40,13 @@ import Agora.Governor (
 import Agora.Proposal (
   Proposal (..),
   ProposalThresholds (..),
+ )
+import Agora.Proposal.Scripts (
   proposalPolicy,
   proposalValidator,
  )
-import Agora.Stake (Stake (..), stakePolicy, stakeValidator)
+import Agora.Stake (Stake (..))
+import Agora.Stake.Scripts (stakePolicy, stakeValidator)
 import Plutarch.Api.V1 (
   mintingPolicySymbol,
   mkMintingPolicy,

--- a/agora-test/Spec/Sample/Shared.hs
+++ b/agora-test/Spec/Sample/Shared.hs
@@ -102,11 +102,8 @@ govSymbol = mintingPolicySymbol govPolicy
 proposal :: Proposal
 proposal =
   Proposal
-    { governorSTAssetClass =
-        -- TODO: if we had a governor here
-        Value.assetClass govSymbol ""
-    , stakeSTAssetClass =
-        Value.assetClass stakeSymbol ""
+    { governorSTAssetClass = Value.assetClass govSymbol ""
+    , stakeSTAssetClass = Value.assetClass stakeSymbol ""
     , maximumCosigners = 6
     }
 

--- a/agora-test/Spec/Sample/Stake.hs
+++ b/agora-test/Spec/Sample/Stake.hs
@@ -69,11 +69,12 @@ stake =
               , "LQ"
               )
           )
+    , proposalSTClass = AssetClass ("", "")
     }
 
 -- | 'Stake' policy instance.
 policy :: MintingPolicy
-policy = mkMintingPolicy (stakePolicy stake)
+policy = mkMintingPolicy (stakePolicy stake.gtClassRef)
 
 policySymbol :: CurrencySymbol
 policySymbol = mintingPolicySymbol policy

--- a/agora-test/Spec/Sample/Stake.hs
+++ b/agora-test/Spec/Sample/Stake.hs
@@ -177,8 +177,7 @@ stakeDepositWithdraw config =
                   [ TxOut
                       { txOutAddress = Address (ScriptCredential $ validatorHash validator) Nothing
                       , txOutValue =
-                          st
-                            <> Value.assetClassValue (untag stake.gtClassRef) (untag stakeAfter.stakedAmount)
+                          st <> Value.assetClassValue (untag stake.gtClassRef) (untag stakeAfter.stakedAmount)
                       , txOutDatumHash = Just (toDatumHash stakeAfter)
                       }
                   ]

--- a/agora-test/Spec/Sample/Stake.hs
+++ b/agora-test/Spec/Sample/Stake.hs
@@ -46,6 +46,7 @@ import Plutus.V1.Ledger.Value qualified as Value
 
 import Agora.SafeMoney (GTTag)
 import Agora.Stake
+import Agora.Stake.Scripts (stakeValidator)
 import Plutarch.SafeMoney
 import Spec.Sample.Shared
 import Spec.Util (datumPair, toDatumHash)

--- a/agora-test/Spec/Stake.hs
+++ b/agora-test/Spec/Stake.hs
@@ -49,7 +49,10 @@ tests =
           (stakePolicy Stake.stake)
           ()
           Stake.stakeCreationUnsigned
-      , validatorSucceedsWith
+      ]
+  , testGroup
+      "validator"
+      [ validatorSucceedsWith
           "stakeDepositWithdraw deposit"
           (stakeValidator Stake.stake)
           (toDatum $ StakeDatum 100_000 signer [])

--- a/agora-test/Spec/Stake.hs
+++ b/agora-test/Spec/Stake.hs
@@ -19,7 +19,7 @@ import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 
-import Agora.Stake (StakeDatum (StakeDatum), StakeRedeemer (DepositWithdraw), stakePolicy, stakeValidator)
+import Agora.Stake (Stake (..), StakeDatum (StakeDatum), StakeRedeemer (DepositWithdraw), stakePolicy, stakeValidator)
 
 --------------------------------------------------------------------------------
 
@@ -36,17 +36,17 @@ tests =
       "policy"
       [ policySucceedsWith
           "stakeCreation"
-          (stakePolicy Stake.stake)
+          (stakePolicy Stake.stake.gtClassRef)
           ()
           Stake.stakeCreation
       , policyFailsWith
           "stakeCreationWrongDatum"
-          (stakePolicy Stake.stake)
+          (stakePolicy Stake.stake.gtClassRef)
           ()
           Stake.stakeCreationWrongDatum
       , policyFailsWith
           "stakeCreationUnsigned"
-          (stakePolicy Stake.stake)
+          (stakePolicy Stake.stake.gtClassRef)
           ()
           Stake.stakeCreationUnsigned
       ]

--- a/agora-test/Spec/Stake.hs
+++ b/agora-test/Spec/Stake.hs
@@ -19,7 +19,8 @@ import Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 
-import Agora.Stake (Stake (..), StakeDatum (StakeDatum), StakeRedeemer (DepositWithdraw), stakePolicy, stakeValidator)
+import Agora.Stake (Stake (..), StakeDatum (StakeDatum), StakeRedeemer (DepositWithdraw))
+import Agora.Stake.Scripts (stakePolicy, stakeValidator)
 
 --------------------------------------------------------------------------------
 

--- a/agora-test/Spec/Util.hs
+++ b/agora-test/Spec/Util.hs
@@ -90,6 +90,7 @@ policyFailsWith tag policy redeemer scriptContext =
 -- | Check that a validator script succeeds, given a name and arguments.
 validatorSucceedsWith ::
   ( PLift datum
+  , Show (PLifted datum)
   , PlutusTx.ToData (PLifted datum)
   , PLift redeemer
   , PlutusTx.ToData (PLifted redeemer)
@@ -100,10 +101,10 @@ validatorSucceedsWith ::
   PLifted redeemer ->
   ScriptContext ->
   TestTree
-validatorSucceedsWith tag policy datum redeemer scriptContext =
+validatorSucceedsWith tag validator datum redeemer scriptContext =
   scriptSucceeds tag $
     compile
-      ( policy
+      ( validator
           # pforgetData (pconstantData datum)
           # pforgetData (pconstantData redeemer)
           # pconstant scriptContext
@@ -122,10 +123,10 @@ validatorFailsWith ::
   PLifted redeemer ->
   ScriptContext ->
   TestTree
-validatorFailsWith tag policy datum redeemer scriptContext =
+validatorFailsWith tag validator datum redeemer scriptContext =
   scriptFails tag $
     compile
-      ( policy
+      ( validator
           # pforgetData (pconstantData datum)
           # pforgetData (pconstantData redeemer)
           # pconstant scriptContext

--- a/agora-test/Spec/Util.hs
+++ b/agora-test/Spec/Util.hs
@@ -90,7 +90,6 @@ policyFailsWith tag policy redeemer scriptContext =
 -- | Check that a validator script succeeds, given a name and arguments.
 validatorSucceedsWith ::
   ( PLift datum
-  , Show (PLifted datum)
   , PlutusTx.ToData (PLifted datum)
   , PLift redeemer
   , PlutusTx.ToData (PLifted redeemer)

--- a/agora.cabal
+++ b/agora.cabal
@@ -134,6 +134,7 @@ library
     Agora.Record
     Agora.SafeMoney
     Agora.Stake
+    Agora.Stake.Scripts
     Agora.Treasury
 
   other-modules:

--- a/agora.cabal
+++ b/agora.cabal
@@ -129,6 +129,7 @@ library
     Agora.Governor
     Agora.MultiSig
     Agora.Proposal
+    Agora.Proposal.Scripts
     Agora.Proposal.Time
     Agora.Record
     Agora.SafeMoney

--- a/agora.cabal
+++ b/agora.cabal
@@ -162,6 +162,8 @@ test-suite agora-test
     Spec.Sample.Effect.TreasuryWithdrawal
     Spec.Sample.Stake
     Spec.Stake
+    Spec.Sample.Proposal
+    Spec.Proposal
     Spec.Util
 
   build-depends:  agora

--- a/agora.cabal
+++ b/agora.cabal
@@ -162,6 +162,7 @@ test-suite agora-test
     Spec.Proposal
     Spec.Sample.Effect.TreasuryWithdrawal
     Spec.Sample.Proposal
+    Spec.Sample.Shared
     Spec.Sample.Stake
     Spec.Stake
     Spec.Util

--- a/agora.cabal
+++ b/agora.cabal
@@ -60,6 +60,7 @@ common lang
     NamedFieldPuns
     NamedWildCards
     NumericUnderscores
+    OverloadedLabels
     OverloadedStrings
     PartialTypeSignatures
     PatternGuards
@@ -78,7 +79,6 @@ common lang
     UndecidableInstances
     ViewPatterns
     OverloadedRecordDot
-    OverloadedLabels
     QualifiedDo
 
   default-language:   Haskell2010
@@ -130,10 +130,10 @@ library
     Agora.MultiSig
     Agora.Proposal
     Agora.Proposal.Time
+    Agora.Record
     Agora.SafeMoney
     Agora.Stake
     Agora.Treasury
-    Agora.Record
 
   other-modules:
     Agora.Utils
@@ -159,11 +159,11 @@ test-suite agora-test
     Spec.AuthorityToken
     Spec.Effect.TreasuryWithdrawal
     Spec.Model.MultiSig
+    Spec.Proposal
     Spec.Sample.Effect.TreasuryWithdrawal
+    Spec.Sample.Proposal
     Spec.Sample.Stake
     Spec.Stake
-    Spec.Sample.Proposal
-    Spec.Proposal
     Spec.Util
 
   build-depends:  agora

--- a/agora.cabal
+++ b/agora.cabal
@@ -78,6 +78,7 @@ common lang
     UndecidableInstances
     ViewPatterns
     OverloadedRecordDot
+    OverloadedLabels
     QualifiedDo
 
   default-language:   Haskell2010
@@ -128,9 +129,11 @@ library
     Agora.Governor
     Agora.MultiSig
     Agora.Proposal
+    Agora.Proposal.Time
     Agora.SafeMoney
     Agora.Stake
     Agora.Treasury
+    Agora.Record
 
   other-modules:
     Agora.Utils

--- a/agora/Agora/AuthorityToken.hs
+++ b/agora/Agora/AuthorityToken.hs
@@ -18,6 +18,7 @@ import Plutarch.Api.V1 (
   PCurrencySymbol (..),
   PScriptContext (..),
   PScriptPurpose (..),
+  PTxInInfo (PTxInInfo),
   PTxInfo (..),
   PTxOut (..),
  )

--- a/agora/Agora/AuthorityToken.hs
+++ b/agora/Agora/AuthorityToken.hs
@@ -145,7 +145,7 @@ authorityTokenPolicy params =
         ( P.do
             passert "Parent token did not move in minting GATs" govTokenSpent
             passert "All outputs only emit valid GATs" $
-              allOutputs @PUnit # pfromData ctx.txInfo #$ plam $ \txOut _value _address _datum ->
+              allOutputs @PData # pfromData ctx.txInfo #$ plam $ \txOut _value _address _datum ->
                 authorityTokensValidIn
                   # ownSymbol
                   # txOut

--- a/agora/Agora/Effect/NoOp.hs
+++ b/agora/Agora/Effect/NoOp.hs
@@ -10,7 +10,6 @@ module Agora.Effect.NoOp (noOpValidator, PNoOp) where
 import Control.Applicative (Const)
 
 import Agora.Effect (makeEffect)
-import Plutarch (popaque)
 import Plutarch.Api.V1 (PValidator)
 import Plutarch.TryFrom (PTryFrom (..))
 import Plutus.V1.Ledger.Value (CurrencySymbol)

--- a/agora/Agora/Effect/NoOp.hs
+++ b/agora/Agora/Effect/NoOp.hs
@@ -14,6 +14,7 @@ import Plutarch.Api.V1 (PValidator)
 import Plutarch.TryFrom (PTryFrom (..))
 import Plutus.V1.Ledger.Value (CurrencySymbol)
 
+-- | Dummy datum for NoOp effect.
 newtype PNoOp (s :: S) = PNoOp (Term s PUnit)
   deriving (PlutusType, PIsData) via (DerivePNewtype PNoOp PUnit)
 

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -40,7 +40,12 @@ import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Value (CurrencySymbol, Value)
 import PlutusTx qualified
 
--- | Datum that encodes behavior of Treasury Withdrawal effect.
+{- | Datum that encodes behavior of Treasury Withdrawal effect.
+
+Note: This Datum acts like a "predefined redeemer". Which is to say that
+it encodes the properties a redeemer would, but is locked in-place until
+spend.
+-}
 data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum
   { receivers :: [(Credential, Value)]
   -- ^ AssocMap for Value sent to each receiver from the treasury.
@@ -51,8 +56,9 @@ data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum
   deriving anyclass (Generic)
 
 PlutusTx.makeLift ''TreasuryWithdrawalDatum
-PlutusTx.unstableMakeIsData ''TreasuryWithdrawalDatum
+PlutusTx.makeIsDataIndexed ''TreasuryWithdrawalDatum [('TreasuryWithdrawalDatum, 0)]
 
+-- | Haskell-level version of 'TreasuryWithdrawalDatum'.
 newtype PTreasuryWithdrawalDatum (s :: S)
   = PTreasuryWithdrawalDatum
       ( Term

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -40,9 +40,12 @@ import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Value (CurrencySymbol, Value)
 import PlutusTx qualified
 
+-- | Datum that encodes behavior of Treasury Withdrawal effect.
 data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum
   { receivers :: [(Credential, Value)]
+  -- ^ AssocMap for Value sent to each receiver from the treasury.
   , treasuries :: [Credential]
+  -- ^ What Credentials is spending from legal.
   }
   deriving stock (Show, GHC.Generic)
   deriving anyclass (Generic)
@@ -77,7 +80,8 @@ deriving via
 instance PTryFrom PData PTreasuryWithdrawalDatum where
   type PTryFromExcess PData PTreasuryWithdrawalDatum = Const ()
   ptryFrom' opq cont =
-    -- this will need to not use punsafeCoerce...
+    -- TODO: This should not use 'punsafeCoerce'.
+    -- Blocked by 'PCredential', and 'PTuple'.
     cont (punsafeCoerce opq, ())
 
 {- | Withdraws given list of values to specific target addresses.
@@ -90,7 +94,7 @@ instance PTryFrom PData PTreasuryWithdrawalDatum where
      Note:
      It should check...
      1. Transaction outputs should contain all of what Datum specified
-     2. Left over assests should be redirected back to Treasury
+     2. Left over assets should be redirected back to Treasury
      It can be more flexiable over...
      - The number of outputs themselves
 -}

--- a/agora/Agora/Governor.hs
+++ b/agora/Agora/Governor.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 {- |
 Module     : Agora.Governor
 Maintainer : emi@haskell.fyi
@@ -21,6 +23,7 @@ module Agora.Governor (
 import Agora.Proposal (ProposalId, ProposalThresholds)
 import Plutarch (popaque)
 import Plutarch.Api.V1 (PMintingPolicy, PValidator)
+import PlutusTx qualified
 
 -- | Datum for the Governor script.
 data GovernorDatum = GovernorDatum
@@ -29,6 +32,8 @@ data GovernorDatum = GovernorDatum
   , nextProposalId :: ProposalId
   -- ^ What tag the next proposal will get upon creating.
   }
+
+PlutusTx.makeIsDataIndexed ''GovernorDatum [('GovernorDatum, 0)]
 
 {- | Redeemer for Governor script. The governor has two primary
      responsibilities:
@@ -42,6 +47,8 @@ data GovernorRedeemer
   | -- | Checks that a SINGLE proposal finished correctly,
     --   and allows minting GATs for each effect script.
     MintGATs
+
+PlutusTx.makeIsDataIndexed ''GovernorRedeemer [('CreateProposal, 0), ('MintGATs, 1)]
 
 -- | Parameters for creating Governor scripts.
 data Governor

--- a/agora/Agora/Governor.hs
+++ b/agora/Agora/Governor.hs
@@ -21,7 +21,6 @@ module Agora.Governor (
 ) where
 
 import Agora.Proposal (ProposalId, ProposalThresholds)
-import Plutarch (popaque)
 import Plutarch.Api.V1 (PMintingPolicy, PValidator)
 import PlutusTx qualified
 

--- a/agora/Agora/MultiSig.hs
+++ b/agora/Agora/MultiSig.hs
@@ -24,6 +24,7 @@ import Plutarch.DataRepr (
   PIsDataReprInstances (PIsDataReprInstances),
  )
 import Plutarch.Lift (
+  PConstantDecl,
   PLifted,
   PUnsafeLiftDecl,
  )
@@ -73,7 +74,7 @@ newtype PMultiSig (s :: S) = PMultiSig
     via (PIsDataReprInstances PMultiSig)
 
 instance PUnsafeLiftDecl PMultiSig where type PLifted PMultiSig = MultiSig
-deriving via (DerivePConstantViaData MultiSig PMultiSig) instance (PConstant MultiSig)
+deriving via (DerivePConstantViaData MultiSig PMultiSig) instance (PConstantDecl MultiSig)
 
 --------------------------------------------------------------------------------
 

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -239,7 +239,7 @@ PlutusTx.makeIsDataIndexed
   ]
 
 -- | Parameters that identify the Proposal validator script.
-data Proposal = Proposal
+newtype Proposal = Proposal
   { governorSTAssetClass :: AssetClass
   }
   deriving stock (Show, Eq)

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -11,6 +11,7 @@ module Agora.Proposal (
   -- * Haskell-land
   Proposal (..),
   ProposalDatum (..),
+  ProposalRedeemer (..),
   ProposalStatus (..),
   ProposalThresholds (..),
   ProposalVotes (..),
@@ -19,6 +20,7 @@ module Agora.Proposal (
 
   -- * Plutarch-land
   PProposalDatum (..),
+  PProposalRedeemer (..),
   PProposalStatus (..),
   PProposalThresholds (..),
   PProposalVotes (..),
@@ -182,12 +184,12 @@ PlutusTx.makeIsDataIndexed ''ProposalDatum [('ProposalDatum, 0)]
 data ProposalRedeemer
   = -- | Cast one or more votes towards a particular 'ResultTag'.
     Vote ResultTag
-  | -- | Add one or more public keys to the cosignature list. Must be signed by
-    --   those cosigning.
+  | -- | Add one or more public keys to the cosignature list.
+    --   Must be signed by those cosigning.
     --
-    --   This is particularly used in the 'Draft' 'ProposalStatus'. Where matching
-    --   'Stake's can be called to advance the proposal, provided enough GT is shared
-    --   among them.
+    --   This is particularly used in the 'Draft' 'ProposalStatus',
+    --   where matching 'Stake's can be called to advance the proposal,
+    --   provided enough GT is shared  among them.
     Cosign [PubKeyHash]
   | -- | Allow unlocking one or more stakes with votes towards particular 'ResultTag'.
     Unlock ResultTag
@@ -195,19 +197,23 @@ data ProposalRedeemer
     --
     --   These are roughly the checks for each possible transition:
     --
-    --   @'Draft' -> 'VotingReady'@:
+    --   === @'Draft' -> 'VotingReady'@:
+    --
     --     1. The sum of all of the cosigner's GT is larger than the 'vote' field of 'ProposalThresholds'.
     --     2. The proposal hasn't been alive for longer than the review time.
     --
-    --   @'VotingReady' -> 'Locked'@:
+    --   === @'VotingReady' -> 'Locked'@:
+    --
     --     1. The sum of all votes is larger than 'countVoting'.
     --     2. The winning 'ResultTag' has more votes than all other 'ResultTag's.
     --     3. The proposal hasn't been alive for longer than the voting time.
     --
-    --   @'Locked' -> 'Finished'@:
+    --   === @'Locked' -> 'Finished'@:
+    --
     --     Always valid provided the conditions for the transition are met.
     --
-    --   @* -> 'Finished'@:
+    --   === @* -> 'Finished'@:
+    --
     --     If the proposal has run out of time for the current 'ProposalStatus', it will always be possible
     --     to transition into 'Finished' state, because it has expired (and failed).
     AdvanceProposal
@@ -221,10 +227,10 @@ PlutusTx.makeIsDataIndexed
   , ('AdvanceProposal, 3)
   ]
 
-{- | Identifies a Proposal, issued upon creation of a proposal.
-     In practice, this number starts at zero, and increments by one
-     for each proposal. The 100th proposal will be @'ProposalId' 99@.
-     This counter lives in the 'Governor', see 'nextProposalId'.
+{- | Identifies a Proposal, issued upon creation of a proposal. In practice,
+     this number starts at zero, and increments by one for each proposal.
+     The 100th proposal will be @'ProposalId' 99@. This counter lives
+     in the 'Agora.Governor.Governor', see 'Agora.Governor.nextProposalId'.
 -}
 newtype ProposalId = ProposalId {proposalTag :: Integer}
   deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -62,10 +62,9 @@ import PlutusTx.AssocMap qualified as AssocMap
 import Agora.SafeMoney (GTTag)
 import Agora.Utils (passert, pnotNull, psymbolValueOf, ptokenSpent, pvalueSpent)
 import Control.Arrow (first)
-import Plutarch (popaque)
 import Plutarch.Api.V1.Extra (passetClass, passetClassValueOf)
 import Plutarch.Builtin (PBuiltinMap)
-import Plutarch.Lift (DerivePConstantViaNewtype (..), PUnsafeLiftDecl (..))
+import Plutarch.Lift (DerivePConstantViaNewtype (..), PConstantDecl, PUnsafeLiftDecl (..))
 import Plutarch.Monadic qualified as P
 import Plutarch.SafeMoney (PDiscrete, Tagged)
 import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
@@ -257,7 +256,7 @@ instance PUnsafeLiftDecl PResultTag where type PLifted PResultTag = ResultTag
 deriving via
   (DerivePConstantViaNewtype ResultTag PResultTag PInteger)
   instance
-    (PConstant ResultTag)
+    (PConstantDecl ResultTag)
 
 -- FIXME: This instance and the one below, for 'PProposalId', should be derived.
 -- Soon this will be possible through 'DerivePNewtype'.
@@ -287,7 +286,7 @@ instance PUnsafeLiftDecl PProposalId where type PLifted PProposalId = ProposalId
 deriving via
   (DerivePConstantViaNewtype ProposalId PProposalId PInteger)
   instance
-    (PConstant ProposalId)
+    (PConstantDecl ProposalId)
 
 -- | Plutarch-level version of 'ProposalStatus'.
 data PProposalStatus (s :: S)
@@ -304,7 +303,7 @@ data PProposalStatus (s :: S)
     via PIsDataReprInstances PProposalStatus
 
 instance PUnsafeLiftDecl PProposalStatus where type PLifted PProposalStatus = ProposalStatus
-deriving via (DerivePConstantViaData ProposalStatus PProposalStatus) instance (PConstant ProposalStatus)
+deriving via (DerivePConstantViaData ProposalStatus PProposalStatus) instance (PConstantDecl ProposalStatus)
 
 -- | Plutarch-level version of 'ProposalThresholds'.
 newtype PProposalThresholds (s :: S) = PProposalThresholds
@@ -326,7 +325,7 @@ newtype PProposalThresholds (s :: S) = PProposalThresholds
     via (PIsDataReprInstances PProposalThresholds)
 
 instance PUnsafeLiftDecl PProposalThresholds where type PLifted PProposalThresholds = ProposalThresholds
-deriving via (DerivePConstantViaData ProposalThresholds PProposalThresholds) instance (PConstant ProposalThresholds)
+deriving via (DerivePConstantViaData ProposalThresholds PProposalThresholds) instance (PConstantDecl ProposalThresholds)
 
 -- | Plutarch-level version of 'ProposalVotes'.
 newtype PProposalVotes (s :: S)
@@ -337,7 +336,7 @@ instance PUnsafeLiftDecl PProposalVotes where type PLifted PProposalVotes = Prop
 deriving via
   (DerivePConstantViaNewtype ProposalVotes PProposalVotes (PMap PResultTag PInteger))
   instance
-    (PConstant ProposalVotes)
+    (PConstantDecl ProposalVotes)
 
 -- | Plutarch-level version of 'ProposalDatum'.
 newtype PProposalDatum (s :: S) = PProposalDatum
@@ -362,7 +361,7 @@ newtype PProposalDatum (s :: S) = PProposalDatum
     via (PIsDataReprInstances PProposalDatum)
 
 instance PUnsafeLiftDecl PProposalDatum where type PLifted PProposalDatum = ProposalDatum
-deriving via (DerivePConstantViaData ProposalDatum PProposalDatum) instance (PConstant ProposalDatum)
+deriving via (DerivePConstantViaData ProposalDatum PProposalDatum) instance (PConstantDecl ProposalDatum)
 
 -- | Haskell-level redeemer for Proposal scripts.
 data PProposalRedeemer (s :: S)
@@ -384,7 +383,7 @@ data PProposalRedeemer (s :: S)
 --     PTryFrom PData (PAsData PProposalRedeemer)
 
 instance PUnsafeLiftDecl PProposalRedeemer where type PLifted PProposalRedeemer = ProposalRedeemer
-deriving via (DerivePConstantViaData ProposalRedeemer PProposalRedeemer) instance (PConstant ProposalRedeemer)
+deriving via (DerivePConstantViaData ProposalRedeemer PProposalRedeemer) instance (PConstantDecl ProposalRedeemer)
 
 --------------------------------------------------------------------------------
 

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -105,8 +105,9 @@ data ProposalStatus
     --   proposal will be able to be voted on.
     VotingReady
   | -- | The proposal has been voted on, and the votes have been locked
-    --   permanently. The proposal can now be executed.
-    Voted
+    --   permanently. The proposal now goes into a locking time after the
+    --   normal voting time. After this, it's possible to execute the proposal.
+    Locked
   | -- | The proposal has finished.
     --
     --   This can mean it's been voted on and completed, but it can also mean
@@ -121,7 +122,7 @@ data ProposalStatus
     Finished
   deriving stock (Eq, Show, GHC.Generic)
 
-PlutusTx.makeIsDataIndexed ''ProposalStatus [('Draft, 0), ('VotingReady, 1), ('Voted, 2), ('Finished, 3)]
+PlutusTx.makeIsDataIndexed ''ProposalStatus [('Draft, 0), ('VotingReady, 1), ('Locked, 2), ('Finished, 3)]
 
 {- | The threshold values for various state transitions to happen.
      This data is stored centrally (in the 'Agora.Governor.Governor') and copied over
@@ -198,12 +199,12 @@ data ProposalRedeemer
     --     1. The sum of all of the cosigner's GT is larger than the 'vote' field of 'ProposalThresholds'.
     --     2. The proposal hasn't been alive for longer than the review time.
     --
-    --   @'VotingReady' -> 'Voted'@:
+    --   @'VotingReady' -> 'Locked'@:
     --     1. The sum of all votes is larger than 'countVoting'.
     --     2. The winning 'ResultTag' has more votes than all other 'ResultTag's.
     --     3. The proposal hasn't been alive for longer than the voting time.
     --
-    --   @'Voted' -> 'Finished'@:
+    --   @'Locked' -> 'Finished'@:
     --     Always valid provided the conditions for the transition are met.
     --
     --   @* -> 'Finished'@:

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -128,6 +128,9 @@ data ProposalThresholds = ProposalThresholds
   -- ^ How much GT minimum must a particular 'ResultTag' accumulate for it to pass.
   , create :: Tagged GTTag Integer
   -- ^ How much GT required to "create" a proposal.
+  --
+  -- It is recommended this be a high enough amount, in order to prevent DOS from bad
+  -- actors.
   , vote :: Tagged GTTag Integer
   -- ^ How much GT required to allow voting to happen.
   -- (i.e. to move into 'VotingReady')

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -304,6 +304,7 @@ data PProposalStatus (s :: S)
     -- e.g. like Tilde used 'pmatchEnum'.
     PDraft (Term s (PDataRecord '[]))
   | PVotingReady (Term s (PDataRecord '[]))
+  | PLocked (Term s (PDataRecord '[]))
   | PFinished (Term s (PDataRecord '[]))
   deriving stock (GHC.Generic)
   deriving anyclass (Generic)

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -252,8 +252,8 @@ instance PTryFrom PData (PAsData PResultTag) where
   ptryFrom' d k =
     ptryFrom' @_ @(PAsData PInteger) d $
       -- JUSTIFICATION:
-      -- We are coercing from @PAsData underlying@ to @PAsData (PTagged tag underlying)@.
-      -- Since 'PTagged' is a simple newtype, their shape is the same.
+      -- We are coercing from @PAsData PInteger@ to @PAsData PResultTag@.
+      -- Since 'PResultTag' is a simple newtype, their shape is the same.
       k . first punsafeCoerce
 
 -- | Plutarch-level version of 'PProposalId'.
@@ -265,8 +265,8 @@ instance PTryFrom PData (PAsData PProposalId) where
   ptryFrom' d k =
     ptryFrom' @_ @(PAsData PInteger) d $
       -- JUSTIFICATION:
-      -- We are coercing from @PAsData underlying@ to @PAsData (PTagged tag underlying)@.
-      -- Since 'PTagged' is a simple newtype, their shape is the same.
+      -- We are coercing from @PAsData PInteger@ to @PAsData PProposalId@.
+      -- Since 'PProposalId' is a simple newtype, their shape is the same.
       k . first punsafeCoerce
 
 instance PUnsafeLiftDecl PProposalId where type PLifted PProposalId = ProposalId

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -109,7 +109,7 @@ data ProposalStatus
     --   the proposal failed due to time constraints or didn't
     --   get to 'VotingReady' first.
     --
-    --   At this stage, the 'votes' field of 'ProposalState' is frozen.
+    --   At this stage, the 'votes' field of 'ProposalDatum' is frozen.
     --
     --   See 'AdvanceProposal' for documentation on state transitions.
     --
@@ -186,7 +186,7 @@ data ProposalRedeemer
     --   Must be signed by those cosigning.
     --
     --   This is particularly used in the 'Draft' 'ProposalStatus',
-    --   where matching 'Stake's can be called to advance the proposal,
+    --   where matching 'Agora.Stake.Stake's can be called to advance the proposal,
     --   provided enough GT is shared  among them.
     Cosign [PubKeyHash]
   | -- | Allow unlocking one or more stakes with votes towards particular 'ResultTag'.
@@ -351,7 +351,7 @@ newtype PProposalDatum (s :: S) = PProposalDatum
 instance PUnsafeLiftDecl PProposalDatum where type PLifted PProposalDatum = ProposalDatum
 deriving via (DerivePConstantViaData ProposalDatum PProposalDatum) instance (PConstantDecl ProposalDatum)
 
--- | Haskell-level redeemer for Proposal scripts.
+-- | Plutarch-level version of 'ProposalRedeemer'.
 data PProposalRedeemer (s :: S)
   = PVote (Term s (PDataRecord '["resultTag" ':= PResultTag]))
   | PCosign (Term s (PDataRecord '["newCosigners" ':= PBuiltinList (PAsData PPubKeyHash)]))

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -26,11 +26,6 @@ module Agora.Proposal (
   PProposalVotes (..),
   PProposalId (..),
   PResultTag (..),
-
-  -- * Scripts
-  proposalValidator,
-  proposalPolicy,
-  proposalDatumValid,
 ) where
 
 import GHC.Generics qualified as GHC
@@ -38,47 +33,26 @@ import Generics.SOP (Generic, I (I))
 import Plutarch.Api.V1 (
   PDatumHash,
   PMap,
-  PMintingPolicy,
   PPubKeyHash,
-  PScriptContext (PScriptContext),
-  PScriptPurpose (PMinting, PSpending),
-  PTxInfo (PTxInfo),
-  PValidator,
   PValidatorHash,
-  mintingPolicySymbol,
-  mkMintingPolicy,
  )
-import Plutarch.DataRepr (
-  DerivePConstantViaData (..),
-  PDataFields,
-  PIsDataReprInstances (PIsDataReprInstances),
- )
-import Plutus.V1.Ledger.Api (DatumHash, PubKeyHash, ValidatorHash)
 import PlutusTx qualified
 import PlutusTx.AssocMap qualified as AssocMap
 
 --------------------------------------------------------------------------------
-import Agora.Record (mkRecordConstr, (.&), (.=))
 import Agora.SafeMoney (GTTag)
-import Agora.Utils (
-  anyOutput,
-  findTxOutByTxOutRef,
-  passert,
-  pnotNull,
-  psymbolValueOf,
-  ptokenSpent,
-  ptxSignedBy,
-  pvalueSpent,
- )
 import Control.Arrow (first)
-import Plutarch.Api.V1.Extra (passetClass, passetClassValueOf)
-import Plutarch.Builtin (PBuiltinMap)
-import Plutarch.Lift (DerivePConstantViaNewtype (..), PConstantDecl, PUnsafeLiftDecl (..))
-import Plutarch.Monadic qualified as P
+import Plutarch.DataRepr (DerivePConstantViaData (..), PDataFields, PIsDataReprInstances (..))
+import Plutarch.Lift (
+  DerivePConstantViaNewtype (..),
+  PConstantDecl,
+  PUnsafeLiftDecl (..),
+ )
 import Plutarch.SafeMoney (PDiscrete, Tagged)
 import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
 import Plutarch.Unsafe (punsafeCoerce)
-import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+import Plutus.V1.Ledger.Api (DatumHash, PubKeyHash, ValidatorHash)
+import Plutus.V1.Ledger.Value (AssetClass)
 
 --------------------------------------------------------------------------------
 -- Haskell-land
@@ -395,161 +369,3 @@ data PProposalRedeemer (s :: S)
 
 instance PUnsafeLiftDecl PProposalRedeemer where type PLifted PProposalRedeemer = ProposalRedeemer
 deriving via (DerivePConstantViaData ProposalRedeemer PProposalRedeemer) instance (PConstantDecl ProposalRedeemer)
-
---------------------------------------------------------------------------------
-
-{- | Policy for Proposals.
-   This needs to perform two checks:
-     - Governor is happy with mint.
-     - Exactly 1 token is minted.
-
-   NOTE: The governor needs to check that the datum is correct
-         and sent to the right address.
--}
-proposalPolicy :: Proposal -> ClosedTerm PMintingPolicy
-proposalPolicy proposal =
-  plam $ \_redeemer ctx' -> P.do
-    PScriptContext ctx' <- pmatch ctx'
-    ctx <- pletFields @'["txInfo", "purpose"] ctx'
-    PTxInfo txInfo' <- pmatch $ pfromData ctx.txInfo
-    txInfo <- pletFields @'["inputs", "mint"] txInfo'
-    PMinting _ownSymbol <- pmatch $ pfromData ctx.purpose
-
-    let inputs = txInfo.inputs
-        mintedValue = pfromData txInfo.mint
-        AssetClass (govCs, govTn) = proposal.governorSTAssetClass
-
-    PMinting ownSymbol' <- pmatch $ pfromData ctx.purpose
-    let mintedProposalST = passetClassValueOf # mintedValue # (passetClass # (pfield @"_0" # ownSymbol') # pconstant "")
-
-    passert "Governance state-thread token must move" $
-      ptokenSpent
-        # (passetClass # pconstant govCs # pconstant govTn)
-        # inputs
-
-    passert "Minted exactly one proposal ST" $
-      mintedProposalST #== 1
-
-    popaque (pconstant ())
-
--- | Validator for Proposals.
-proposalValidator :: Proposal -> ClosedTerm PValidator
-proposalValidator proposal =
-  plam $ \datum redeemer ctx' -> P.do
-    PScriptContext ctx' <- pmatch ctx'
-    ctx <- pletFields @'["txInfo", "purpose"] ctx'
-    txInfo <- plet $ pfromData ctx.txInfo
-    PTxInfo txInfo' <- pmatch txInfo
-    txInfoF <- pletFields @'["inputs", "mint"] txInfo'
-    PSpending ((pfield @"_0" #) -> txOutRef) <- pmatch $ pfromData ctx.purpose
-
-    PJust txOut <- pmatch $ findTxOutByTxOutRef # txOutRef # txInfoF.inputs
-    txOutF <- pletFields @'["address", "value"] $ txOut
-
-    let proposalDatum :: Term _ PProposalDatum
-        proposalDatum = pfromData $ punsafeCoerce datum
-        proposalRedeemer :: Term _ PProposalRedeemer
-        proposalRedeemer = pfromData $ punsafeCoerce redeemer
-
-    proposalF <-
-      pletFields
-        @'[ "proposalId"
-          , "effects"
-          , "status"
-          , "cosigners"
-          , "thresholds"
-          , "votes"
-          ]
-        proposalDatum
-
-    ownAddress <- plet $ txOutF.address
-
-    stCurrencySymbol <- plet $ pconstant $ mintingPolicySymbol $ mkMintingPolicy (proposalPolicy proposal)
-    valueSpent <- plet $ pvalueSpent # txInfoF.inputs
-    spentST <- plet $ psymbolValueOf # stCurrencySymbol #$ valueSpent
-    let AssetClass (stakeSym, stakeTn) = proposal.stakeSTAssetClass
-    spentStakeST <- plet $ passetClassValueOf # valueSpent # (passetClass # pconstant stakeSym # pconstant stakeTn)
-
-    pmatch proposalRedeemer $ \case
-      PVote _r -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PCosign r -> P.do
-        newSigs <- plet $ pfield @"newCosigners" # r
-
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-
-        passert "Signed by all new cosigners" $
-          pall # plam (\sig -> ptxSignedBy # ctx.txInfo # sig) # newSigs
-
-        passert "As many new cosigners as Stake datums" $
-          spentStakeST #== plength # newSigs
-
-        passert "Signatures are correctly added to cosignature list" $
-          anyOutput @PProposalDatum # ctx.txInfo
-            #$ plam
-            $ \newValue address newProposalDatum -> P.do
-              -- This is a little sad. Can we do better by
-              -- building a new ProposalDatum and then comparing?
-              let correctDatum =
-                    pdata newProposalDatum
-                      #== pdata
-                        ( mkRecordConstr
-                            PProposalDatum
-                            ( #proposalId .= proposalF.proposalId
-                                .& #effects .= proposalF.effects
-                                .& #status .= proposalF.status
-                                .& #cosigners .= pdata (pconcat # newSigs # proposalF.cosigners)
-                                .& #thresholds .= proposalF.thresholds
-                                .& #votes .= proposalF.votes
-                            )
-                        )
-
-              foldr1
-                (#&&)
-                [ pcon PTrue
-                , ptraceIfFalse "Datum must be correct" correctDatum
-                , ptraceIfFalse "Value should be correct" $ pdata txOutF.value #== pdata newValue
-                , ptraceIfFalse "Must be sent to Proposal's address" $ ownAddress #== pdata address
-                ]
-
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PUnlock _r -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PAdvanceProposal _r -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-
-        popaque (pconstant ())
-
-{- | Check for various invariants a proposal must uphold.
-     This can be used to check both upopn creation and
-     upon any following state transitions in the proposal.
--}
-proposalDatumValid :: Term s (PProposalDatum :--> PBool)
-proposalDatumValid =
-  phoistAcyclic $
-    plam $ \datum' -> P.do
-      datum <- pletFields @'["effects", "cosigners"] $ datum'
-
-      let effects :: Term _ (PBuiltinMap PResultTag (PBuiltinMap PValidatorHash PDatumHash))
-          effects = punsafeCoerce datum.effects
-
-          atLeastOneNegativeResult :: Term _ PBool
-          atLeastOneNegativeResult =
-            pany # plam (\pair -> pnull #$ pfromData $ psndBuiltin # pair) # effects
-
-      foldr1
-        (#&&)
-        [ ptraceIfFalse "Proposal has at least one ResultTag has no effects" atLeastOneNegativeResult
-        , ptraceIfFalse "Proposal has at least one cosigner" $ pnotNull # pfromData datum.cosigners
-        ]

--- a/agora/Agora/Proposal/Scripts.hs
+++ b/agora/Agora/Proposal/Scripts.hs
@@ -1,3 +1,10 @@
+{- |
+Module     : Agora.Proposal.Scripts
+Maintainer : emi@haskell.fyi
+Description: Plutus Scripts for Proposals.
+
+Plutus Scripts for Proposals.
+-}
 module Agora.Proposal.Scripts (
   proposalValidator,
   proposalPolicy,

--- a/agora/Agora/Proposal/Scripts.hs
+++ b/agora/Agora/Proposal/Scripts.hs
@@ -1,0 +1,227 @@
+module Agora.Proposal.Scripts (
+  proposalValidator,
+  proposalPolicy,
+  proposalDatumValid,
+) where
+
+import Agora.Proposal
+import Agora.Record (mkRecordConstr, (.&), (.=))
+import Agora.Stake (PStakeDatum)
+import Agora.Utils (
+  anyOutput,
+  findTxOutByTxOutRef,
+  passert,
+  pfindDatum',
+  pnotNull,
+  psymbolValueOf,
+  ptokenSpent,
+  ptxSignedBy,
+  pvalueSpent,
+ )
+import Plutarch.Api.V1 (
+  PDatumHash,
+  PMaybeData (PDJust, PDNothing),
+  PMintingPolicy,
+  PPubKeyHash,
+  PScriptContext (PScriptContext),
+  PScriptPurpose (PMinting, PSpending),
+  PTxInInfo (PTxInInfo),
+  PTxInfo (PTxInfo),
+  PTxOut (PTxOut),
+  PValidator,
+  PValidatorHash,
+  mintingPolicySymbol,
+  mkMintingPolicy,
+ )
+import Plutarch.Api.V1.Extra (passetClass, passetClassValueOf)
+import Plutarch.Builtin (PBuiltinMap)
+import Plutarch.Monadic qualified as P
+import Plutarch.Unsafe (punsafeCoerce)
+import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+
+{- | Policy for Proposals.
+   This needs to perform two checks:
+     - Governor is happy with mint.
+     - Exactly 1 token is minted.
+
+   NOTE: The governor needs to check that the datum is correct
+         and sent to the right address.
+-}
+proposalPolicy :: Proposal -> ClosedTerm PMintingPolicy
+proposalPolicy proposal =
+  plam $ \_redeemer ctx' -> P.do
+    PScriptContext ctx' <- pmatch ctx'
+    ctx <- pletFields @'["txInfo", "purpose"] ctx'
+    PTxInfo txInfo' <- pmatch $ pfromData ctx.txInfo
+    txInfo <- pletFields @'["inputs", "mint"] txInfo'
+    PMinting _ownSymbol <- pmatch $ pfromData ctx.purpose
+
+    let inputs = txInfo.inputs
+        mintedValue = pfromData txInfo.mint
+        AssetClass (govCs, govTn) = proposal.governorSTAssetClass
+
+    PMinting ownSymbol' <- pmatch $ pfromData ctx.purpose
+    let mintedProposalST = passetClassValueOf # mintedValue # (passetClass # (pfield @"_0" # ownSymbol') # pconstant "")
+
+    passert "Governance state-thread token must move" $
+      ptokenSpent
+        # (passetClass # pconstant govCs # pconstant govTn)
+        # inputs
+
+    passert "Minted exactly one proposal ST" $
+      mintedProposalST #== 1
+
+    popaque (pconstant ())
+
+-- | Validator for Proposals.
+proposalValidator :: Proposal -> ClosedTerm PValidator
+proposalValidator proposal =
+  plam $ \datum redeemer ctx' -> P.do
+    PScriptContext ctx' <- pmatch ctx'
+    ctx <- pletFields @'["txInfo", "purpose"] ctx'
+    txInfo <- plet $ pfromData ctx.txInfo
+    PTxInfo txInfo' <- pmatch txInfo
+    txInfoF <- pletFields @'["inputs", "mint"] txInfo'
+    PSpending ((pfield @"_0" #) -> txOutRef) <- pmatch $ pfromData ctx.purpose
+
+    PJust txOut <- pmatch $ findTxOutByTxOutRef # txOutRef # txInfoF.inputs
+    txOutF <- pletFields @'["address", "value"] $ txOut
+
+    let proposalDatum :: Term _ PProposalDatum
+        proposalDatum = pfromData $ punsafeCoerce datum
+        proposalRedeemer :: Term _ PProposalRedeemer
+        proposalRedeemer = pfromData $ punsafeCoerce redeemer
+
+    proposalF <-
+      pletFields
+        @'[ "proposalId"
+          , "effects"
+          , "status"
+          , "cosigners"
+          , "thresholds"
+          , "votes"
+          ]
+        proposalDatum
+
+    ownAddress <- plet $ txOutF.address
+
+    stCurrencySymbol <- plet $ pconstant $ mintingPolicySymbol $ mkMintingPolicy (proposalPolicy proposal)
+    valueSpent <- plet $ pvalueSpent # txInfoF.inputs
+    spentST <- plet $ psymbolValueOf # stCurrencySymbol #$ valueSpent
+    let AssetClass (stakeSym, stakeTn) = proposal.stakeSTAssetClass
+    stakeSTAssetClass <- plet $ passetClass # pconstant stakeSym # pconstant stakeTn
+    spentStakeST <- plet $ passetClassValueOf # valueSpent # stakeSTAssetClass
+
+    pmatch proposalRedeemer $ \case
+      PVote _r -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PCosign r -> P.do
+        newSigs <- plet $ pfield @"newCosigners" # r
+
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+
+        passert "Signed by all new cosigners" $
+          pall # plam (\sig -> ptxSignedBy # ctx.txInfo # sig) # newSigs
+
+        passert "As many new cosigners as Stake datums" $
+          spentStakeST #== plength # newSigs
+
+        let stakeDatumOwnedBy :: Term _ (PPubKeyHash :--> PStakeDatum :--> PBool)
+            stakeDatumOwnedBy =
+              phoistAcyclic $
+                plam $ \pk stakeDatum -> P.do
+                  stakeDatumF <- pletFields @'["owner"] $ pto stakeDatum
+                  stakeDatumF.owner #== pdata pk
+
+        -- Does the input have a `Stake` owned by a particular PK?
+        let isInputStakeOwnedBy :: Term _ (PAsData PPubKeyHash :--> PAsData PTxInInfo :--> PBool)
+            isInputStakeOwnedBy =
+              plam $ \ss txInInfo' -> P.do
+                PTxInInfo ((pfield @"resolved" #) -> txOut) <- pmatch $ pfromData txInInfo'
+                PTxOut txOut' <- pmatch txOut
+                txOutF <- pletFields @'["value", "datumHash"] txOut'
+                outStakeST <- plet $ passetClassValueOf # txOutF.value # stakeSTAssetClass
+                pmatch txOutF.datumHash $ \case
+                  PDNothing _ -> pcon PFalse
+                  PDJust ((pfield @"_0" #) -> datumHash) ->
+                    pif
+                      (outStakeST #== 1)
+                      -- TODO: use 'ptryFindDatum' instead in the future
+                      ( pmatch (pfindDatum' # datumHash # txInfo) $ \case
+                          PNothing -> pcon PFalse
+                          PJust v -> stakeDatumOwnedBy # pfromData ss # pfromData v
+                      )
+                      (pcon PFalse)
+
+        passert "All new cosigners are witnessed by their Stake datums" $
+          pall
+            # plam (\sig -> pany # (isInputStakeOwnedBy # sig) # txInfoF.inputs)
+            # newSigs
+
+        passert "Signatures are correctly added to cosignature list" $
+          anyOutput @PProposalDatum # ctx.txInfo
+            #$ plam
+            $ \newValue address newProposalDatum -> P.do
+              let correctDatum =
+                    pdata newProposalDatum
+                      #== pdata
+                        ( mkRecordConstr
+                            PProposalDatum
+                            ( #proposalId .= proposalF.proposalId
+                                .& #effects .= proposalF.effects
+                                .& #status .= proposalF.status
+                                .& #cosigners .= pdata (pconcat # newSigs # proposalF.cosigners)
+                                .& #thresholds .= proposalF.thresholds
+                                .& #votes .= proposalF.votes
+                            )
+                        )
+
+              foldr1
+                (#&&)
+                [ pcon PTrue
+                , ptraceIfFalse "Datum must be correct" correctDatum
+                , ptraceIfFalse "Value should be correct" $ pdata txOutF.value #== pdata newValue
+                , ptraceIfFalse "Must be sent to Proposal's address" $ ownAddress #== pdata address
+                ]
+
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PUnlock _r -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PAdvanceProposal _r -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+
+        popaque (pconstant ())
+
+{- | Check for various invariants a proposal must uphold.
+     This can be used to check both upopn creation and
+     upon any following state transitions in the proposal.
+-}
+proposalDatumValid :: Term s (PProposalDatum :--> PBool)
+proposalDatumValid =
+  phoistAcyclic $
+    plam $ \datum' -> P.do
+      datum <- pletFields @'["effects", "cosigners"] $ datum'
+
+      let effects :: Term _ (PBuiltinMap PResultTag (PBuiltinMap PValidatorHash PDatumHash))
+          effects = punsafeCoerce datum.effects
+
+          atLeastOneNegativeResult :: Term _ PBool
+          atLeastOneNegativeResult =
+            pany # plam (\pair -> pnull #$ pfromData $ psndBuiltin # pair) # effects
+
+      foldr1
+        (#&&)
+        [ ptraceIfFalse "Proposal has at least one ResultTag has no effects" atLeastOneNegativeResult
+        , ptraceIfFalse "Proposal has at least one cosigner" $ pnotNull # pfromData datum.cosigners
+        ]

--- a/agora/Agora/Proposal/Scripts.hs
+++ b/agora/Agora/Proposal/Scripts.hs
@@ -212,8 +212,7 @@ proposalValidator proposal =
 
               foldr1
                 (#&&)
-                [ pcon PTrue
-                , ptraceIfFalse "Datum must be correct" correctDatum
+                [ ptraceIfFalse "Datum must be correct" correctDatum
                 , ptraceIfFalse "Value should be correct" $
                     pdata txOutF.value #== pdata newValue
                 , ptraceIfFalse "Must be sent to Proposal's address" $

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -20,34 +20,52 @@ module Agora.Proposal.Time (
   PProposalStartingTime (..),
 
   -- * Compute ranges given config and starting time.
-  proposalDraftRange,
-
-  -- * Upstreamables
-  plowerBound,
-  pupperBound,
-  pstrictLowerBound,
-  pstrictUpperBound,
+  currentProposalTime,
+  isDraftRange,
 ) where
 
 import Agora.Record (build, (.&), (.=))
 import GHC.Generics qualified as GHC
 import Generics.SOP (Generic, I (I))
-import Plutarch.Api.V1 (PExtended (PFinite), PInterval (PInterval), PLowerBound (PLowerBound), PPOSIXTime, PPOSIXTimeRange, PUpperBound (PUpperBound))
+import Plutarch.Api.V1 (PExtended (PFinite), PInterval (PInterval), PLowerBound (PLowerBound), PMaybeData (PDJust, PDNothing), PPOSIXTime, PPOSIXTimeRange, PUpperBound (PUpperBound))
 import Plutarch.DataRepr (PDataFields, PIsDataReprInstances (..))
+import Plutarch.Monadic qualified as P
 import Plutarch.Numeric (AdditiveSemigroup ((+)))
 import Plutarch.Unsafe (punsafeCoerce)
-import Plutus.V1.Ledger.Time (POSIXTime, POSIXTimeRange)
+import Plutus.V1.Ledger.Time (POSIXTime)
 import PlutusTx qualified
 import Prelude hiding ((+))
 
 --------------------------------------------------------------------------------
 
--- | Represents the current time, as far as the proposal is concerned.
-newtype ProposalTime = ProposalTime
-  { getProposalTime :: POSIXTimeRange
+{- | == Establishing timing in Proposal interactions.
+
+   In Plutus, it's impossible to determine time exactly. It's also impossible
+   to get a single point in time, yet often we need to check
+   various constraints on time.
+
+   For the purposes of proposals, there's a single most important feature:
+   The ability to determine if we can perform an action. In order to correctly
+   determine if we are able to perform certain actions, we need to know what
+   time it roughly is, compared to when the proposal got created.
+
+   'ProposalTime' represents "the time according to the proposal".
+   Its representation is opaque, and doesn't matter.
+
+   Various functions work simply on 'ProposalTime' and 'ProposalTimingConfig'.
+   In particular, 'currentProposalTime' is useful for extracting the time
+   from the 'Plutus.V1.Ledger.Api.txInfoValidRange' field
+   of 'Plutus.V1.Ledger.Api.TxInfo'.
+
+   We avoid 'PPOSIXTimeRange' where we can in order to save on operations.
+-}
+data ProposalTime = ProposalTime
+  { lowerBound :: Maybe POSIXTime
+  , upperBound :: Maybe POSIXTime
   }
-  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
   deriving stock (Eq, Show, GHC.Generic)
+
+PlutusTx.makeIsDataIndexed ''ProposalTime [('ProposalTime, 0)]
 
 -- | Represents the starting time of the proposal.
 newtype ProposalStartingTime = ProposalStartingTime
@@ -74,8 +92,22 @@ PlutusTx.makeIsDataIndexed ''ProposalTimingConfig [('ProposalTimingConfig, 0)]
 --------------------------------------------------------------------------------
 
 -- | Plutarch-level version of 'ProposalTime'.
-newtype PProposalTime (s :: S) = PProposalTime (Term s PPOSIXTime)
-  deriving (PlutusType, PIsData, PEq, POrd) via (DerivePNewtype PProposalTime PPOSIXTime)
+newtype PProposalTime (s :: S)
+  = PProposalTime
+      ( Term
+          s
+          ( PDataRecord
+              '[ "lowerBound" ':= PMaybeData PPOSIXTime
+               , "upperBound" ':= PMaybeData PPOSIXTime
+               ]
+          )
+      )
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic)
+  deriving anyclass (PIsDataRepr)
+  deriving
+    (PlutusType, PIsData, PDataFields)
+    via (PIsDataReprInstances PProposalTime)
 
 -- | Plutarch-level version of 'ProposalStartingTime'.
 newtype PProposalStartingTime (s :: S) = PProposalStartingTime (Term s PPOSIXTime)
@@ -103,58 +135,56 @@ newtype PProposalTimingConfig (s :: S) = PProposalTimingConfig
 
 --------------------------------------------------------------------------------
 
--- -- Need to move these away from here
-pstrictLowerBound :: PIsData a => Term s (a :--> PLowerBound a)
-pstrictLowerBound = phoistAcyclic $
-  plam $ \a ->
-    pcon
-      ( PLowerBound $
-          build $
-            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
-              .& #_1 .= pdata (pcon PFalse)
-      )
-
-pstrictUpperBound :: PIsData a => Term s (a :--> PUpperBound a)
-pstrictUpperBound = phoistAcyclic $
-  plam $ \a ->
-    pcon
-      ( PUpperBound $
-          build $
-            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
-              .& #_1 .= pdata (pcon PFalse)
-      )
-
-plowerBound :: PIsData a => Term s (a :--> PLowerBound a)
-plowerBound = phoistAcyclic $
-  plam $ \a ->
-    pcon
-      ( PLowerBound $
-          build $
-            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
-              .& #_1 .= pdata (pcon PTrue)
-      )
-
-pupperBound :: PIsData a => Term s (a :--> PUpperBound a)
-pupperBound = phoistAcyclic $
-  plam $ \a ->
-    pcon
-      ( PUpperBound $
-          build $
-            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
-              .& #_1 .= pdata (pcon PTrue)
-      )
-
--- Move this to plutarch-extra.
+-- FIXME: Orphan instance, move this to plutarch-extra.
 instance AdditiveSemigroup (Term s PPOSIXTime) where
   (punsafeCoerce @_ @_ @PInteger -> x) + (punsafeCoerce @_ @_ @PInteger -> y) = punsafeCoerce $ x + y
 
--- | Compute the range of time during which cosigning is legal.
-proposalDraftRange :: Term s (PPOSIXTime :--> PProposalTimingConfig :--> PPOSIXTimeRange)
-proposalDraftRange = phoistAcyclic $
-  plam $ \s config ->
+-- | Get the current proposal time, from the 'txInfoValidRange' field.
+currentProposalTime :: forall (s :: S). Term s (PPOSIXTimeRange :--> PProposalTime)
+currentProposalTime = phoistAcyclic $
+  plam $ \iv -> P.do
+    PInterval iv' <- pmatch iv
+    ivf <- pletFields @'["from", "to"] iv'
+    PLowerBound lb <- pmatch ivf.from
+    PUpperBound ub <- pmatch ivf.to
+    lbf <- pletFields @'["_0", "_1"] lb
+    ubf <- pletFields @'["_0", "_1"] ub
     pcon
-      ( PInterval $
+      ( PProposalTime $
           build $
-            #from .= pdata (pstrictLowerBound # s)
-              .& #to .= pdata (pstrictUpperBound #$ s + pfield @"draftTime" # config)
+            #lowerBound
+              .= pdata
+                ( pmatch lbf._0 $
+                    \case
+                      PFinite d -> pcon (PDJust d)
+                      _ -> pcon (PDNothing pdnil)
+                )
+              .& #upperBound
+              .= pdata
+                ( pmatch ubf._0 $ \case
+                    PFinite d -> pcon (PDJust d)
+                    _ -> pcon (PDNothing pdnil)
+                )
       )
+
+-- | Check if 'PProposalTime' is within two 'PPOSIXTime'. Inclusive.
+proposalTimeWithin :: Term s (PPOSIXTime :--> PPOSIXTime :--> PProposalTime :--> PBool)
+proposalTimeWithin = phoistAcyclic $
+  plam $ \l h proposalTime' -> P.do
+    PProposalTime proposalTime <- pmatch proposalTime'
+    ptf <- pletFields @'["lowerBound", "upperBound"] proposalTime
+    foldr1
+      (#&&)
+      [ pmatch ptf.lowerBound $ \case
+          PDJust lb -> l #<= pfromData (pfield @"_0" # lb)
+          _ -> pcon PFalse
+      , pmatch ptf.upperBound $ \case
+          PDJust lb -> pfromData (pfield @"_0" # lb) #<= h
+          _ -> pcon PFalse
+      ]
+
+-- | True if the 'PProposalTime' is in the draft period.
+isDraftRange :: forall (s :: S). Term s (PProposalTimingConfig :--> PProposalStartingTime :--> PProposalTime :--> PBool)
+isDraftRange = phoistAcyclic $
+  plam $ \config s' -> pmatch s' $ \(PProposalStartingTime s) ->
+    proposalTimeWithin # s # (s + pfield @"draftTime" # config)

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -27,7 +27,15 @@ module Agora.Proposal.Time (
 import Agora.Record (mkRecordConstr, (.&), (.=))
 import GHC.Generics qualified as GHC
 import Generics.SOP (Generic, I (I))
-import Plutarch.Api.V1 (PExtended (PFinite), PInterval (PInterval), PLowerBound (PLowerBound), PMaybeData (PDJust, PDNothing), PPOSIXTime, PPOSIXTimeRange, PUpperBound (PUpperBound))
+import Plutarch.Api.V1 (
+  PExtended (PFinite),
+  PInterval (PInterval),
+  PLowerBound (PLowerBound),
+  PMaybeData (PDJust, PDNothing),
+  PPOSIXTime,
+  PPOSIXTimeRange,
+  PUpperBound (PUpperBound),
+ )
 import Plutarch.DataRepr (PDataFields, PIsDataReprInstances (..))
 import Plutarch.Monadic qualified as P
 import Plutarch.Numeric (AdditiveSemigroup ((+)))
@@ -74,16 +82,19 @@ newtype ProposalStartingTime = ProposalStartingTime
   deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
   deriving stock (Eq, Show, GHC.Generic)
 
--- | Configuration of proposal timings.
+{- | Configuration of proposal timings.
+
+ See: https://github.com/Liqwid-Labs/agora/blob/master/docs/tech-design/proposals.md#when-may-interactions-occur
+-}
 data ProposalTimingConfig = ProposalTimingConfig
   { draftTime :: POSIXTime
-  -- ^ `D`: the length of the draft period.
+  -- ^ "D": the length of the draft period.
   , votingTime :: POSIXTime
-  -- ^ `V`: the length of the voting period.
+  -- ^ "V": the length of the voting period.
   , lockingTime :: POSIXTime
-  -- ^ `L`: the length of the locking period.
+  -- ^ "L": the length of the locking period.
   , executingTime :: POSIXTime
-  -- ^ `E`: the length of the execution period.
+  -- ^ "E": the length of the execution period.
   }
   deriving stock (Eq, Show, GHC.Generic)
 
@@ -139,7 +150,7 @@ newtype PProposalTimingConfig (s :: S) = PProposalTimingConfig
 instance AdditiveSemigroup (Term s PPOSIXTime) where
   (punsafeCoerce @_ @_ @PInteger -> x) + (punsafeCoerce @_ @_ @PInteger -> y) = punsafeCoerce $ x + y
 
--- | Get the current proposal time, from the 'txInfoValidRange' field.
+-- | Get the current proposal time, from the 'Plutus.V1.Ledger.Api.txInfoValidRange' field.
 currentProposalTime :: forall (s :: S). Term s (PPOSIXTimeRange :--> PProposalTime)
 currentProposalTime = phoistAcyclic $
   plam $ \iv -> P.do

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -24,7 +24,7 @@ module Agora.Proposal.Time (
   isDraftRange,
 ) where
 
-import Agora.Record (build, (.&), (.=))
+import Agora.Record (mkRecordConstr, (.&), (.=))
 import GHC.Generics qualified as GHC
 import Generics.SOP (Generic, I (I))
 import Plutarch.Api.V1 (PExtended (PFinite), PInterval (PInterval), PLowerBound (PLowerBound), PMaybeData (PDJust, PDNothing), PPOSIXTime, PPOSIXTimeRange, PUpperBound (PUpperBound))
@@ -149,23 +149,20 @@ currentProposalTime = phoistAcyclic $
     PUpperBound ub <- pmatch ivf.to
     lbf <- pletFields @'["_0", "_1"] lb
     ubf <- pletFields @'["_0", "_1"] ub
-    pcon
-      ( PProposalTime $
-          build $
-            #lowerBound
-              .= pdata
-                ( pmatch lbf._0 $
-                    \case
-                      PFinite d -> pcon (PDJust d)
-                      _ -> pcon (PDNothing pdnil)
-                )
-              .& #upperBound
-              .= pdata
-                ( pmatch ubf._0 $ \case
-                    PFinite d -> pcon (PDJust d)
-                    _ -> pcon (PDNothing pdnil)
-                )
-      )
+    mkRecordConstr PProposalTime $
+      #lowerBound
+        .= pdata
+          ( pmatch lbf._0 $
+              \case
+                PFinite d -> pcon (PDJust d)
+                _ -> pcon (PDNothing pdnil)
+          )
+        .& #upperBound
+        .= pdata
+          ( pmatch ubf._0 $ \case
+              PFinite d -> pcon (PDJust d)
+              _ -> pcon (PDNothing pdnil)
+          )
 
 -- | Check if 'PProposalTime' is within two 'PPOSIXTime'. Inclusive.
 proposalTimeWithin :: Term s (PPOSIXTime :--> PPOSIXTime :--> PProposalTime :--> PBool)

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- |
+Module     : Agora.Proposal.Time
+Maintainer : emi@haskell.fyi
+Description: Time functions for proposal phases.
+
+Time functions for proposal phases.
+-}
+module Agora.Proposal.Time (
+  -- * Haskell-land
+  ProposalTime (..),
+  ProposalTimingConfig (..),
+  ProposalStartingTime (..),
+
+  -- * Plutarch-land
+  PProposalTime (..),
+  PProposalTimingConfig (..),
+  PProposalStartingTime (..),
+
+  -- * Compute ranges given config and starting time.
+  proposalDraftRange,
+
+  -- * Upstreamables
+  plowerBound,
+  pupperBound,
+  pstrictLowerBound,
+  pstrictUpperBound,
+) where
+
+import Agora.Record (build, (.&), (.=))
+import GHC.Generics qualified as GHC
+import Generics.SOP (Generic, I (I))
+import Plutarch.Api.V1 (PExtended (PFinite), PInterval (PInterval), PLowerBound (PLowerBound), PPOSIXTime, PPOSIXTimeRange, PUpperBound (PUpperBound))
+import Plutarch.DataRepr (PDataFields, PIsDataReprInstances (..))
+import Plutarch.Numeric (AdditiveSemigroup ((+)))
+import Plutarch.Unsafe (punsafeCoerce)
+import Plutus.V1.Ledger.Time (POSIXTime, POSIXTimeRange)
+import PlutusTx qualified
+import Prelude hiding ((+))
+
+--------------------------------------------------------------------------------
+
+-- | Represents the current time, as far as the proposal is concerned.
+newtype ProposalTime = ProposalTime
+  { getProposalTime :: POSIXTimeRange
+  }
+  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
+  deriving stock (Eq, Show, GHC.Generic)
+
+-- | Represents the starting time of the proposal.
+newtype ProposalStartingTime = ProposalStartingTime
+  { getProposalStartingTime :: POSIXTime
+  }
+  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
+  deriving stock (Eq, Show, GHC.Generic)
+
+-- | Configuration of proposal timings.
+data ProposalTimingConfig = ProposalTimingConfig
+  { draftTime :: POSIXTime
+  -- ^ `D`: the length of the draft period.
+  , votingTime :: POSIXTime
+  -- ^ `V`: the length of the voting period.
+  , lockingTime :: POSIXTime
+  -- ^ `L`: the length of the locking period.
+  , executingTime :: POSIXTime
+  -- ^ `E`: the length of the execution period.
+  }
+  deriving stock (Eq, Show, GHC.Generic)
+
+PlutusTx.makeIsDataIndexed ''ProposalTimingConfig [('ProposalTimingConfig, 0)]
+
+--------------------------------------------------------------------------------
+
+-- | Plutarch-level version of 'ProposalTime'.
+newtype PProposalTime (s :: S) = PProposalTime (Term s PPOSIXTime)
+  deriving (PlutusType, PIsData, PEq, POrd) via (DerivePNewtype PProposalTime PPOSIXTime)
+
+-- | Plutarch-level version of 'ProposalStartingTime'.
+newtype PProposalStartingTime (s :: S) = PProposalStartingTime (Term s PPOSIXTime)
+  deriving (PlutusType, PIsData, PEq, POrd) via (DerivePNewtype PProposalStartingTime PPOSIXTime)
+
+-- | Plutarch-level version of 'ProposalTimingConfig'.
+newtype PProposalTimingConfig (s :: S) = PProposalTimingConfig
+  { getProposalTimingConfig ::
+    Term
+      s
+      ( PDataRecord
+          '[ "draftTime" ':= PPOSIXTime
+           , "votingTime" ':= PPOSIXTime
+           , "lockingTime" ':= PPOSIXTime
+           , "executingTime" ':= PPOSIXTime
+           ]
+      )
+  }
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic)
+  deriving anyclass (PIsDataRepr)
+  deriving
+    (PlutusType, PIsData, PDataFields)
+    via (PIsDataReprInstances PProposalTimingConfig)
+
+--------------------------------------------------------------------------------
+
+-- -- Need to move these away from here
+pstrictLowerBound :: PIsData a => Term s (a :--> PLowerBound a)
+pstrictLowerBound = phoistAcyclic $
+  plam $ \a ->
+    pcon
+      ( PLowerBound $
+          build $
+            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
+              .& #_1 .= pdata (pcon PFalse)
+      )
+
+pstrictUpperBound :: PIsData a => Term s (a :--> PUpperBound a)
+pstrictUpperBound = phoistAcyclic $
+  plam $ \a ->
+    pcon
+      ( PUpperBound $
+          build $
+            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
+              .& #_1 .= pdata (pcon PFalse)
+      )
+
+plowerBound :: PIsData a => Term s (a :--> PLowerBound a)
+plowerBound = phoistAcyclic $
+  plam $ \a ->
+    pcon
+      ( PLowerBound $
+          build $
+            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
+              .& #_1 .= pdata (pcon PTrue)
+      )
+
+pupperBound :: PIsData a => Term s (a :--> PUpperBound a)
+pupperBound = phoistAcyclic $
+  plam $ \a ->
+    pcon
+      ( PUpperBound $
+          build $
+            #_0 .= pdata (pcon (PFinite $ build $ #_0 .= pdata a))
+              .& #_1 .= pdata (pcon PTrue)
+      )
+
+-- Move this to plutarch-extra.
+instance AdditiveSemigroup (Term s PPOSIXTime) where
+  (punsafeCoerce @_ @_ @PInteger -> x) + (punsafeCoerce @_ @_ @PInteger -> y) = punsafeCoerce $ x + y
+
+-- | Compute the range of time during which cosigning is legal.
+proposalDraftRange :: Term s (PPOSIXTime :--> PProposalTimingConfig :--> PPOSIXTimeRange)
+proposalDraftRange = phoistAcyclic $
+  plam $ \s config ->
+    pcon
+      ( PInterval $
+          build $
+            #from .= pdata (pstrictLowerBound # s)
+              .& #to .= pdata (pstrictUpperBound #$ s + pfield @"draftTime" # config)
+      )

--- a/agora/Agora/Record.hs
+++ b/agora/Agora/Record.hs
@@ -48,8 +48,7 @@ infix 7 .=
   forall (sym :: Symbol) (a :: PType) (as :: [PLabeledType]) (s :: S).
   FieldName sym ->
   Term s (PAsData a) ->
-  ( RecordMorphism s as ((sym ':= a) ': as)
-  )
+  RecordMorphism s as ((sym ':= a) ': as)
 _ .= x = RecordMorphism $ pcon . PDCons x
 
 infixr 6 .&

--- a/agora/Agora/Record.hs
+++ b/agora/Agora/Record.hs
@@ -61,7 +61,7 @@ infixr 6 .&
     (a :: [PLabeledType])
     (b :: [PLabeledType])
     (c :: [PLabeledType]).
-  (RecordMorphism s b c) ->
-  (RecordMorphism s a b) ->
-  (RecordMorphism s a c)
+  RecordMorphism s b c ->
+  RecordMorphism s a b ->
+  RecordMorphism s a c
 (.&) = (.)

--- a/agora/Agora/Record.hs
+++ b/agora/Agora/Record.hs
@@ -1,0 +1,67 @@
+{- |
+Module     : Agora.Record
+Maintainer : emi@haskell.fyi
+Description: PDataRecord helper functions.
+
+PDataRecord helper functions.
+-}
+module Agora.Record (build, (.=), (.&)) where
+
+import Control.Category (Category (..))
+import Data.Coerce (coerce)
+import GHC.OverloadedLabels (IsLabel (fromLabel))
+import GHC.TypeLits (Symbol)
+import Plutarch.DataRepr (PDataRecord (PDCons))
+import Prelude hiding (id, (.))
+
+-- | Like 'Data.Proxy.Proxy' but local to this module.
+data FieldName (sym :: Symbol) = FieldName
+
+{- | The use of two different 'Symbol's here allows unification to happen,
+     ensuring 'FieldName' has a fully inferred 'Symbol'.
+
+     For example, @'build' (#foo .= 'pconstantData' (42 :: 'Integer'))@ gets
+     the correct type. Namely, @'Term' s ('PDataRecord' '["foo" ':= 'PInteger'])@.
+-}
+instance forall (sym :: Symbol) (sym' :: Symbol). sym ~ sym' => IsLabel sym (FieldName sym') where
+  fromLabel = FieldName
+
+-- | Turn a builder into a fully built 'PDataRecord'.
+build :: forall (s :: S) (r :: [PLabeledType]). RecordMorphism s '[] r -> Term s (PDataRecord r)
+build f = coerce f pdnil
+
+-- | A morphism from one PDataRecord to another, representing some sort of consing of data.
+newtype RecordMorphism (s :: S) (as :: [PLabeledType]) (bs :: [PLabeledType]) = RecordMorphism
+  { runRecordMorphism ::
+    Term s (PDataRecord as) ->
+    Term s (PDataRecord bs)
+  }
+
+instance Category (RecordMorphism s) where
+  id = RecordMorphism id
+  f . g = coerce $ f.runRecordMorphism . g.runRecordMorphism
+
+infix 7 .=
+
+-- | Cons a labeled type as a 'RecordMorphism'.
+(.=) ::
+  forall (sym :: Symbol) (a :: PType) (as :: [PLabeledType]) (s :: S).
+  FieldName sym ->
+  Term s (PAsData a) ->
+  ( RecordMorphism s as ((sym ':= a) ': as)
+  )
+_ .= x = RecordMorphism $ pcon . PDCons x
+
+infixr 6 .&
+
+-- | Compose two morphisms between records.
+(.&) ::
+  forall
+    (s :: S)
+    (a :: [PLabeledType])
+    (b :: [PLabeledType])
+    (c :: [PLabeledType]).
+  (RecordMorphism s b c) ->
+  (RecordMorphism s a b) ->
+  (RecordMorphism s a c)
+(.&) = (.)

--- a/agora/Agora/Record.hs
+++ b/agora/Agora/Record.hs
@@ -60,7 +60,8 @@ mkRecordConstr ::
   forall (r :: [PLabeledType]) (s :: S) (pt :: PType).
   PlutusType pt =>
   -- | The constructor. This is just the Haskell-level constructor for the type.
-  --   For 'PMaybeData', this could be 'PDJust', or 'PNothing'.
+  --   For 'Plutarch.Api.V1.Maybe.PMaybeData', this would
+  --   be 'Plutarch.Api.V1.Maybe.PDJust', or 'Plutarch.Api.V1.Maybe.PNothing'.
   (forall s'. Term s' (PDataRecord r) -> pt s') ->
   -- | The morphism that builds the record.
   RecordMorphism s '[] r ->
@@ -87,7 +88,7 @@ infix 7 .=
   --   @#hello ~ 'FieldName' "hello"@
   FieldName sym ->
   -- | The value at that field. This must be 'PAsData', because the underlying
-  --   type is @'Constr' 'Integer' ['Data']@.
+  --   type is @'PlutusCore.Data.Constr' 'Integer' ['PlutusCore.Data.Data']@.
   Term s (PAsData a) ->
   RecordMorphism s as ((sym ':= a) ': as)
 _ .= x = RecordMorphism $ pcon . PDCons x

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -33,7 +33,6 @@ import PlutusTx qualified
 
 --------------------------------------------------------------------------------
 
-import Plutarch (popaque)
 import Plutarch.Api.V1 (
   PCredential (PPubKeyCredential, PScriptCredential),
   PMintingPolicy,
@@ -50,7 +49,7 @@ import Plutarch.DataRepr (
   PIsDataReprInstances (PIsDataReprInstances),
  )
 import Plutarch.Internal (punsafeCoerce)
-import Plutarch.Lift (PUnsafeLiftDecl (..))
+import Plutarch.Lift (PConstantDecl, PUnsafeLiftDecl (..))
 import Plutarch.Monadic qualified as P
 import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
 
@@ -197,7 +196,7 @@ newtype PStakeDatum (s :: S) = PStakeDatum
     via (PIsDataReprInstances PStakeDatum)
 
 instance PUnsafeLiftDecl PStakeDatum where type PLifted PStakeDatum = StakeDatum
-deriving via (DerivePConstantViaData StakeDatum PStakeDatum) instance (PConstant StakeDatum)
+deriving via (DerivePConstantViaData StakeDatum PStakeDatum) instance (PConstantDecl StakeDatum)
 
 -- | Plutarch-level redeemer for Stake scripts.
 data PStakeRedeemer (s :: S)
@@ -220,7 +219,7 @@ deriving via
     PTryFrom PData (PAsData PStakeRedeemer)
 
 instance PUnsafeLiftDecl PStakeRedeemer where type PLifted PStakeRedeemer = StakeRedeemer
-deriving via (DerivePConstantViaData StakeRedeemer PStakeRedeemer) instance (PConstant StakeRedeemer)
+deriving via (DerivePConstantViaData StakeRedeemer PStakeRedeemer) instance (PConstantDecl StakeRedeemer)
 
 newtype PProposalLock (s :: S) = PProposalLock
   { getProposalLock ::
@@ -245,7 +244,7 @@ deriving via
     PTryFrom PData (PAsData PProposalLock)
 
 instance PUnsafeLiftDecl PProposalLock where type PLifted PProposalLock = ProposalLock
-deriving via (DerivePConstantViaData ProposalLock PProposalLock) instance (PConstant ProposalLock)
+deriving via (DerivePConstantViaData ProposalLock PProposalLock) instance (PConstantDecl ProposalLock)
 
 --------------------------------------------------------------------------------
 {- What this Policy does

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -441,8 +441,6 @@ stakeValidator stake =
           anyOutput @PStakeDatum # txInfo
             #$ plam
             $ \value address newStakeDatum' -> P.do
-              PStakeDatum newStakeDatum <- pmatch newStakeDatum'
-              newStakeDatumF <- pletFields @'["stakedAmount"] newStakeDatum
               let isScriptAddress = pdata address #== ownAddress
               let correctOutputDatum = pdata newStakeDatum' #== pdata stakeDatum'
               let valueCorrect = pdata continuingValue #== pdata value

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -127,14 +127,14 @@ data StakeRedeemer
   | -- | Destroy a stake, retrieving its LQ, the minimum ADA and any other assets.
     --   Stake must be unlocked.
     Destroy
-  | -- | Permit a Vote to be added onto a 'Proposal'.
+  | -- | Permit a Vote to be added onto a 'Agora.Proposal.Proposal'.
     --   This also adds a lock to the 'lockedBy' field. See 'ProposalLock'.
     --   This needs to be done in sync with casting a vote, otherwise
     --   it's possible for a lock to be permanently placed on the stake,
     --   and then the funds are lost.
     PermitVote ProposalLock
   | -- | Retract a vote, removing it from the 'lockedBy' field. See 'ProposalLock'.
-    --   This action checks for permission of the 'Proposal'. Finished proposals are
+    --   This action checks for permission of the 'Agora.Proposal.Proposal'. Finished proposals are
     --   always allowed to have votes retracted and won't affect the Proposal datum,
     --   allowing 'Stake's to be unlocked.
     RetractVotes [ProposalLock]
@@ -156,7 +156,7 @@ PlutusTx.makeIsDataIndexed
 data StakeDatum = StakeDatum
   { stakedAmount :: Tagged GTTag Integer
   -- ^ Tracks the amount of governance token staked in the datum.
-  -- This also acts as the voting weight for 'Proposal's.
+  -- This also acts as the voting weight for 'Agora.Proposal.Proposal's.
   , owner :: PubKeyHash
   -- ^ The hash of the public key this stake belongs to.
   --
@@ -218,6 +218,7 @@ deriving via
 instance PUnsafeLiftDecl PStakeRedeemer where type PLifted PStakeRedeemer = StakeRedeemer
 deriving via (DerivePConstantViaData StakeRedeemer PStakeRedeemer) instance (PConstantDecl StakeRedeemer)
 
+-- | Plutarch-level version of 'ProposalLock'.
 newtype PProposalLock (s :: S) = PProposalLock
   { getProposalLock ::
     Term

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -8,15 +8,18 @@ Description: Vote-lockable stake UTXOs holding GT.
 Vote-lockable stake UTXOs holding GT.
 -}
 module Agora.Stake (
-  PStakeDatum (..),
-  PStakeRedeemer (..),
+  -- * Haskell-land
   StakeDatum (..),
   StakeRedeemer (..),
-  ProposalLock (..),
-  PProposalLock (..),
   Stake (..),
-  stakePolicy,
-  stakeValidator,
+  ProposalLock (..),
+
+  -- * Plutarch-land
+  PStakeDatum (..),
+  PStakeRedeemer (..),
+  PProposalLock (..),
+
+  -- * Utility functions
   stakeLocked,
   findStakeOwnedBy,
 ) where
@@ -35,21 +38,13 @@ import PlutusTx qualified
 --------------------------------------------------------------------------------
 
 import Plutarch.Api.V1 (
-  PCredential (PPubKeyCredential, PScriptCredential),
   PDatum,
   PDatumHash,
   PMaybeData (PDJust, PDNothing),
-  PMintingPolicy,
   PPubKeyHash,
-  PScriptPurpose (PMinting, PSpending),
-  PTokenName,
   PTuple,
   PTxInInfo (PTxInInfo),
-  PTxInfo,
   PTxOut (PTxOut),
-  PValidator,
-  mintingPolicySymbol,
-  mkMintingPolicy,
  )
 import Plutarch.DataRepr (
   DerivePConstantViaData (..),
@@ -59,38 +54,23 @@ import Plutarch.DataRepr (
 import Plutarch.Internal (punsafeCoerce)
 import Plutarch.Lift (PConstantDecl, PUnsafeLiftDecl (..))
 import Plutarch.Monadic qualified as P
-import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+import Plutus.V1.Ledger.Value (AssetClass)
 
 --------------------------------------------------------------------------------
 
 import Agora.Proposal (PProposalId, PResultTag, ProposalId (..), ResultTag (..))
 import Agora.SafeMoney (GTTag)
 import Agora.Utils (
-  anyInput,
-  anyOutput,
-  paddValue,
-  passert,
   pfindDatum,
-  pfindTxInByTxOutRef,
-  pgeqByClass,
-  pgeqByClass',
-  pgeqBySymbol,
   pnotNull,
-  psingletonValue,
-  psymbolValueOf,
-  ptokenSpent,
-  ptxSignedBy,
-  pvalueSpent,
  )
-import Plutarch.Api.V1.Extra (PAssetClass, passetClass, passetClassValueOf)
-import Plutarch.Numeric
+import Plutarch.Api.V1.Extra (PAssetClass, passetClassValueOf)
+import Plutarch.Numeric ()
 import Plutarch.SafeMoney (
   PDiscrete,
   Tagged (..),
-  pdiscreteValue',
-  untag,
  )
-import Plutarch.TryFrom (PTryFrom, ptryFrom)
+import Plutarch.TryFrom (PTryFrom)
 
 --------------------------------------------------------------------------------
 
@@ -262,256 +242,6 @@ deriving via
 
 instance PUnsafeLiftDecl PProposalLock where type PLifted PProposalLock = ProposalLock
 deriving via (DerivePConstantViaData ProposalLock PProposalLock) instance (PConstantDecl ProposalLock)
-
---------------------------------------------------------------------------------
-{- What this Policy does
-
-   For minting:
-     Check that exactly one state thread is minted
-     Check that an output exists with a state thread and a valid datum
-     Check that no state thread is an input
-     assert TokenName == ValidatorHash of the script that we pay to
-
-   For burning:
-     Check that exactly one state thread is burned
-     Check that datum at state thread is valid and not locked
--}
---------------------------------------------------------------------------------
-
--- | Policy for Stake state threads.
-stakePolicy :: Tagged GTTag AssetClass -> ClosedTerm PMintingPolicy
-stakePolicy gtClassRef =
-  plam $ \_redeemer ctx' -> P.do
-    ctx <- pletFields @'["txInfo", "purpose"] ctx'
-    txInfo <- plet $ ctx.txInfo
-    let _a :: Term _ PTxInfo
-        _a = txInfo
-    txInfoF <- pletFields @'["mint", "inputs", "outputs", "signatories"] txInfo
-
-    PMinting ownSymbol' <- pmatch $ pfromData ctx.purpose
-    ownSymbol <- plet $ pfield @"_0" # ownSymbol'
-    spentST <- plet $ psymbolValueOf # ownSymbol #$ pvalueSpent # txInfoF.inputs
-    mintedST <- plet $ psymbolValueOf # ownSymbol # txInfoF.mint
-
-    let burning = P.do
-          passert "ST at inputs must be 1" $
-            spentST #== 1
-
-          passert "ST burned" $
-            mintedST #== -1
-
-          passert "An unlocked input existed containing an ST" $
-            anyInput @PStakeDatum # txInfo
-              #$ plam
-              $ \value _ stakeDatum' -> P.do
-                let hasST = psymbolValueOf # ownSymbol # value #== 1
-                let unlocked = pnot # (stakeLocked # stakeDatum')
-                hasST #&& unlocked
-
-          popaque (pconstant ())
-
-    let minting = P.do
-          passert "ST at inputs must be 0" $
-            spentST #== 0
-
-          passert "Minted ST must be exactly 1" $
-            mintedST #== 1
-
-          passert "A UTXO must exist with the correct output" $
-            anyOutput @PStakeDatum # txInfo
-              #$ plam
-              $ \value address stakeDatum' -> P.do
-                let cred = pfield @"credential" # address
-                pmatch cred $ \case
-                  -- Should pay to a script address
-                  PPubKeyCredential _ -> pcon PFalse
-                  PScriptCredential validatorHash' -> P.do
-                    validatorHash <- pletFields @'["_0"] validatorHash'
-                    stakeDatum <- pletFields @'["owner", "stakedAmount"] stakeDatum'
-
-                    -- TODO: figure out why this is required :/ (specifically, why `validatorHash._0` is `PData`)
-                    tn <- plet (pfromData (punsafeCoerce validatorHash._0 :: Term _ (PAsData PTokenName)))
-
-                    let stValue =
-                          psingletonValue
-                            # ownSymbol
-                            -- This coerce is safe because the structure
-                            -- of PValidatorHash is the same as PTokenName.
-                            # tn
-                            # 1
-                    let expectedValue =
-                          paddValue
-                            # (pdiscreteValue' gtClassRef # stakeDatum.stakedAmount)
-                            # stValue
-                    let ownerSignsTransaction =
-                          ptxSignedBy
-                            # txInfoF.signatories
-                            # stakeDatum.owner
-
-                    -- TODO: This is quite inefficient now, as it does two lookups
-                    -- instead of a more efficient single pass,
-                    -- but it doesn't really matter for this. At least it's correct.
-                    let valueCorrect =
-                          foldr1
-                            (#&&)
-                            [ pgeqByClass' (AssetClass ("", "")) # value # expectedValue
-                            , pgeqByClass' (untag gtClassRef)
-                                # value
-                                # expectedValue
-                            , pgeqByClass
-                                # ownSymbol
-                                # tn
-                                # value
-                                # expectedValue
-                            ]
-
-                    ownerSignsTransaction
-                      #&& valueCorrect
-          popaque (pconstant ())
-
-    pif (0 #< mintedST) minting burning
-
---------------------------------------------------------------------------------
-
--- | Validator intended for Stake UTXOs to live in.
-stakeValidator :: Stake -> ClosedTerm PValidator
-stakeValidator stake =
-  plam $ \datum redeemer ctx' -> P.do
-    ctx <- pletFields @'["txInfo", "purpose"] ctx'
-    txInfo <- plet $ pfromData ctx.txInfo
-    txInfoF <- pletFields @'["mint", "inputs", "outputs", "signatories"] txInfo
-
-    (pfromData -> stakeRedeemer, _) <- ptryFrom redeemer
-
-    -- TODO: Use PTryFrom
-    let stakeDatum' :: Term _ PStakeDatum
-        stakeDatum' = pfromData $ punsafeCoerce datum
-    stakeDatum <- pletFields @'["owner", "stakedAmount"] stakeDatum'
-
-    PSpending txOutRef <- pmatch $ pfromData ctx.purpose
-
-    PJust txInInfo <- pmatch $ pfindTxInByTxOutRef # (pfield @"_0" # txOutRef) # txInfoF.inputs
-    ownAddress <- plet $ pfield @"address" #$ pfield @"resolved" # txInInfo
-    let continuingValue = pfield @"value" #$ pfield @"resolved" # txInInfo
-
-    -- Whether the owner signs this transaction or not.
-    ownerSignsTransaction <- plet $ ptxSignedBy # txInfoF.signatories # stakeDatum.owner
-
-    stCurrencySymbol <- plet $ pconstant $ mintingPolicySymbol $ mkMintingPolicy (stakePolicy stake.gtClassRef)
-    mintedST <- plet $ psymbolValueOf # stCurrencySymbol # txInfoF.mint
-    spentST <- plet $ psymbolValueOf # stCurrencySymbol #$ pvalueSpent # txInfoF.inputs
-
-    -- Is the stake currently locked?
-    stakeIsLocked <- plet $ stakeLocked # stakeDatum'
-
-    pmatch stakeRedeemer $ \case
-      PDestroy _ -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-        passert "Should burn ST" $
-          mintedST #== -1
-        passert "Stake unlocked" $ pnot # stakeIsLocked
-        passert
-          "Owner signs this transaction"
-          ownerSignsTransaction
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PRetractVotes _ -> P.do
-        passert
-          "Owner signs this transaction"
-          ownerSignsTransaction
-        -- TODO: check proposal constraints
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PPermitVote _ -> P.do
-        passert
-          "Owner signs this transaction"
-          ownerSignsTransaction
-        -- TODO: check proposal constraints
-        popaque (pconstant ())
-      --------------------------------------------------------------------------
-      PWitnessStake _ -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-
-        let AssetClass (propCs, propTn) = stake.proposalSTClass
-            propAssetClass = passetClass # pconstant propCs # pconstant propTn
-            proposalTokenMoved =
-              ptokenSpent
-                # propAssetClass
-                # txInfoF.inputs
-
-        passert
-          "Owner signs this transaction OR proposal token is spent"
-          (ownerSignsTransaction #|| proposalTokenMoved)
-
-        passert "A UTXO must exist with the correct output" $
-          anyOutput @PStakeDatum # txInfo
-            #$ plam
-            $ \value address newStakeDatum' -> P.do
-              let isScriptAddress = pdata address #== ownAddress
-              let correctOutputDatum = pdata newStakeDatum' #== pdata stakeDatum'
-              let valueCorrect = pdata continuingValue #== pdata value
-              pif
-                isScriptAddress
-                ( foldl1
-                    (#&&)
-                    [ ptraceIfFalse "valueCorrect" valueCorrect
-                    , ptraceIfFalse "correctOutputDatum" correctOutputDatum
-                    ]
-                )
-                (pcon PFalse)
-        popaque (pconstant ())
-      PDepositWithdraw r -> P.do
-        passert "ST at inputs must be 1" $
-          spentST #== 1
-        passert "Stake unlocked" $
-          pnot #$ stakeIsLocked
-        passert
-          "Owner signs this transaction"
-          ownerSignsTransaction
-        passert "A UTXO must exist with the correct output" $
-          anyOutput @PStakeDatum # txInfo
-            #$ plam
-            $ \value address newStakeDatum' -> P.do
-              newStakeDatum <- pletFields @'["owner", "stakedAmount"] newStakeDatum'
-              delta <- plet $ pfield @"delta" # r
-              let isScriptAddress = pdata address #== ownAddress
-              let correctOutputDatum =
-                    foldr1
-                      (#&&)
-                      [ stakeDatum.owner #== newStakeDatum.owner
-                      , (stakeDatum.stakedAmount + delta) #== newStakeDatum.stakedAmount
-                      , -- We can't magically conjure GT anyway (no input to spend!)
-                        -- do we need to check this, really?
-                        zero #<= pfromData newStakeDatum.stakedAmount
-                      ]
-              let expectedValue = paddValue # continuingValue # (pdiscreteValue' stake.gtClassRef # delta)
-
-              -- TODO: Same as above. This is quite inefficient now, as it does two lookups
-              -- instead of a more efficient single pass,
-              -- but it doesn't really matter for this. At least it's correct.
-              let valueCorrect =
-                    foldr1
-                      (#&&)
-                      [ pgeqByClass' (AssetClass ("", "")) # value # expectedValue
-                      , pgeqByClass' (untag stake.gtClassRef)
-                          # value
-                          # expectedValue
-                      , pgeqBySymbol
-                          # stCurrencySymbol
-                          # value
-                          # expectedValue
-                      ]
-
-              foldr1
-                (#&&)
-                [ ptraceIfFalse "isScriptAddress" isScriptAddress
-                , ptraceIfFalse "correctOutputDatum" correctOutputDatum
-                , ptraceIfFalse "valueCorrect" valueCorrect
-                ]
-
-        popaque (pconstant ())
 
 --------------------------------------------------------------------------------
 

--- a/agora/Agora/Stake/Scripts.hs
+++ b/agora/Agora/Stake/Scripts.hs
@@ -54,15 +54,16 @@ import Prelude hiding (Num (..))
 
    === For minting:
 
-   - Check that exactly one state thread is minted
-   - Check that an output exists with a state thread and a valid datum
-   - Check that no state thread is an input
-   - assert @'TokenName' == 'ValidatorHash'@ of the script that we pay to
+   - Check that exactly one state thread is minted.
+   - Check that an output exists with a state thread and a valid datum.
+   - Check that no state thread is an input.
+   - assert @'Plutus.V1.Ledger.Api.TokenName' == 'Plutus.V1.Ledger.Api.ValidatorHash'@
+     of the script that we pay to.
 
    === For burning:
 
-   - Check that exactly one state thread is burned
-   - Check that datum at state thread is valid and not locked
+   - Check that exactly one state thread is burned.
+   - Check that datum at state thread is valid and not locked.
 -}
 stakePolicy :: Tagged GTTag AssetClass -> ClosedTerm PMintingPolicy
 stakePolicy gtClassRef =

--- a/agora/Agora/Stake/Scripts.hs
+++ b/agora/Agora/Stake/Scripts.hs
@@ -1,0 +1,297 @@
+{- |
+Module     : Agora.Stake.Scripts
+Maintainer : emi@haskell.fyi
+Description: Plutus Scripts for Stakes.
+
+Plutus Scripts for Stakes.
+-}
+module Agora.Stake.Scripts (stakePolicy, stakeValidator) where
+
+import Agora.SafeMoney (GTTag)
+import Agora.Stake
+import Agora.Utils (
+  anyInput,
+  anyOutput,
+  paddValue,
+  passert,
+  pfindTxInByTxOutRef,
+  pgeqByClass,
+  pgeqByClass',
+  pgeqBySymbol,
+  psingletonValue,
+  psymbolValueOf,
+  ptokenSpent,
+  ptxSignedBy,
+  pvalueSpent,
+  validatorHashToTokenName,
+ )
+import Plutarch.Api.V1 (
+  PCredential (PPubKeyCredential, PScriptCredential),
+  PMintingPolicy,
+  PScriptPurpose (PMinting, PSpending),
+  PTokenName,
+  PTxInfo,
+  PValidator,
+  mintingPolicySymbol,
+  mkMintingPolicy,
+ )
+import Plutarch.Api.V1.Extra (passetClass)
+import Plutarch.Internal (punsafeCoerce)
+import Plutarch.Monadic qualified as P
+import Plutarch.Numeric
+import Plutarch.SafeMoney (
+  Tagged (..),
+  pdiscreteValue',
+  untag,
+ )
+import Plutarch.TryFrom (ptryFrom)
+import Plutus.V1.Ledger.Value (AssetClass (AssetClass))
+import Prelude hiding (Num (..))
+
+{- | Policy for Stake state threads.
+
+   == What this Policy does
+
+   === For minting:
+
+   - Check that exactly one state thread is minted
+   - Check that an output exists with a state thread and a valid datum
+   - Check that no state thread is an input
+   - assert @'TokenName' == 'ValidatorHash'@ of the script that we pay to
+
+   === For burning:
+
+   - Check that exactly one state thread is burned
+   - Check that datum at state thread is valid and not locked
+-}
+stakePolicy :: Tagged GTTag AssetClass -> ClosedTerm PMintingPolicy
+stakePolicy gtClassRef =
+  plam $ \_redeemer ctx' -> P.do
+    ctx <- pletFields @'["txInfo", "purpose"] ctx'
+    txInfo <- plet $ ctx.txInfo
+    let _a :: Term _ PTxInfo
+        _a = txInfo
+    txInfoF <- pletFields @'["mint", "inputs", "outputs", "signatories"] txInfo
+
+    PMinting ownSymbol' <- pmatch $ pfromData ctx.purpose
+    ownSymbol <- plet $ pfield @"_0" # ownSymbol'
+    spentST <- plet $ psymbolValueOf # ownSymbol #$ pvalueSpent # txInfoF.inputs
+    mintedST <- plet $ psymbolValueOf # ownSymbol # txInfoF.mint
+
+    let burning = P.do
+          passert "ST at inputs must be 1" $
+            spentST #== 1
+
+          passert "ST burned" $
+            mintedST #== -1
+
+          passert "An unlocked input existed containing an ST" $
+            anyInput @PStakeDatum # txInfo
+              #$ plam
+              $ \value _ stakeDatum' -> P.do
+                let hasST = psymbolValueOf # ownSymbol # value #== 1
+                let unlocked = pnot # (stakeLocked # stakeDatum')
+                hasST #&& unlocked
+
+          popaque (pconstant ())
+
+    let minting = P.do
+          passert "ST at inputs must be 0" $
+            spentST #== 0
+
+          passert "Minted ST must be exactly 1" $
+            mintedST #== 1
+
+          passert "A UTXO must exist with the correct output" $
+            anyOutput @PStakeDatum # txInfo
+              #$ plam
+              $ \value address stakeDatum' -> P.do
+                let cred = pfield @"credential" # address
+                pmatch cred $ \case
+                  -- Should pay to a script address
+                  PPubKeyCredential _ -> pcon PFalse
+                  PScriptCredential validatorHash -> P.do
+                    stakeDatum <- pletFields @'["owner", "stakedAmount"] stakeDatum'
+
+                    tn :: Term _ PTokenName <- plet (validatorHashToTokenName $ pfromData $ pfield @"_0" # validatorHash)
+
+                    let stValue =
+                          psingletonValue
+                            # ownSymbol
+                            -- This coerce is safe because the structure
+                            -- of PValidatorHash is the same as PTokenName.
+                            # tn
+                            # 1
+                    let expectedValue =
+                          paddValue
+                            # (pdiscreteValue' gtClassRef # stakeDatum.stakedAmount)
+                            # stValue
+                    let ownerSignsTransaction =
+                          ptxSignedBy
+                            # txInfoF.signatories
+                            # stakeDatum.owner
+
+                    -- TODO: This is quite inefficient now, as it does two lookups
+                    -- instead of a more efficient single pass,
+                    -- but it doesn't really matter for this. At least it's correct.
+                    let valueCorrect =
+                          foldr1
+                            (#&&)
+                            [ pgeqByClass' (AssetClass ("", "")) # value # expectedValue
+                            , pgeqByClass' (untag gtClassRef)
+                                # value
+                                # expectedValue
+                            , pgeqByClass
+                                # ownSymbol
+                                # tn
+                                # value
+                                # expectedValue
+                            ]
+
+                    ownerSignsTransaction
+                      #&& valueCorrect
+          popaque (pconstant ())
+
+    pif (0 #< mintedST) minting burning
+
+--------------------------------------------------------------------------------
+
+-- | Validator intended for Stake UTXOs to live in.
+stakeValidator :: Stake -> ClosedTerm PValidator
+stakeValidator stake =
+  plam $ \datum redeemer ctx' -> P.do
+    ctx <- pletFields @'["txInfo", "purpose"] ctx'
+    txInfo <- plet $ pfromData ctx.txInfo
+    txInfoF <- pletFields @'["mint", "inputs", "outputs", "signatories"] txInfo
+
+    (pfromData -> stakeRedeemer, _) <- ptryFrom redeemer
+
+    -- TODO: Use PTryFrom
+    let stakeDatum' :: Term _ PStakeDatum
+        stakeDatum' = pfromData $ punsafeCoerce datum
+    stakeDatum <- pletFields @'["owner", "stakedAmount"] stakeDatum'
+
+    PSpending txOutRef <- pmatch $ pfromData ctx.purpose
+
+    PJust txInInfo <- pmatch $ pfindTxInByTxOutRef # (pfield @"_0" # txOutRef) # txInfoF.inputs
+    ownAddress <- plet $ pfield @"address" #$ pfield @"resolved" # txInInfo
+    let continuingValue = pfield @"value" #$ pfield @"resolved" # txInInfo
+
+    -- Whether the owner signs this transaction or not.
+    ownerSignsTransaction <- plet $ ptxSignedBy # txInfoF.signatories # stakeDatum.owner
+
+    stCurrencySymbol <- plet $ pconstant $ mintingPolicySymbol $ mkMintingPolicy (stakePolicy stake.gtClassRef)
+    mintedST <- plet $ psymbolValueOf # stCurrencySymbol # txInfoF.mint
+    spentST <- plet $ psymbolValueOf # stCurrencySymbol #$ pvalueSpent # txInfoF.inputs
+
+    -- Is the stake currently locked?
+    stakeIsLocked <- plet $ stakeLocked # stakeDatum'
+
+    pmatch stakeRedeemer $ \case
+      PDestroy _ -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+        passert "Should burn ST" $
+          mintedST #== -1
+        passert "Stake unlocked" $ pnot # stakeIsLocked
+        passert
+          "Owner signs this transaction"
+          ownerSignsTransaction
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PRetractVotes _ -> P.do
+        passert
+          "Owner signs this transaction"
+          ownerSignsTransaction
+        -- TODO: check proposal constraints
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PPermitVote _ -> P.do
+        passert
+          "Owner signs this transaction"
+          ownerSignsTransaction
+        -- TODO: check proposal constraints
+        popaque (pconstant ())
+      --------------------------------------------------------------------------
+      PWitnessStake _ -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+
+        let AssetClass (propCs, propTn) = stake.proposalSTClass
+            propAssetClass = passetClass # pconstant propCs # pconstant propTn
+            proposalTokenMoved =
+              ptokenSpent
+                # propAssetClass
+                # txInfoF.inputs
+
+        passert
+          "Owner signs this transaction OR proposal token is spent"
+          (ownerSignsTransaction #|| proposalTokenMoved)
+
+        passert "A UTXO must exist with the correct output" $
+          anyOutput @PStakeDatum # txInfo
+            #$ plam
+            $ \value address newStakeDatum' -> P.do
+              let isScriptAddress = pdata address #== ownAddress
+              let correctOutputDatum = pdata newStakeDatum' #== pdata stakeDatum'
+              let valueCorrect = pdata continuingValue #== pdata value
+              pif
+                isScriptAddress
+                ( foldl1
+                    (#&&)
+                    [ ptraceIfFalse "valueCorrect" valueCorrect
+                    , ptraceIfFalse "correctOutputDatum" correctOutputDatum
+                    ]
+                )
+                (pcon PFalse)
+        popaque (pconstant ())
+      PDepositWithdraw r -> P.do
+        passert "ST at inputs must be 1" $
+          spentST #== 1
+        passert "Stake unlocked" $
+          pnot #$ stakeIsLocked
+        passert
+          "Owner signs this transaction"
+          ownerSignsTransaction
+        passert "A UTXO must exist with the correct output" $
+          anyOutput @PStakeDatum # txInfo
+            #$ plam
+            $ \value address newStakeDatum' -> P.do
+              newStakeDatum <- pletFields @'["owner", "stakedAmount"] newStakeDatum'
+              delta <- plet $ pfield @"delta" # r
+              let isScriptAddress = pdata address #== ownAddress
+              let correctOutputDatum =
+                    foldr1
+                      (#&&)
+                      [ stakeDatum.owner #== newStakeDatum.owner
+                      , (stakeDatum.stakedAmount + delta) #== newStakeDatum.stakedAmount
+                      , -- We can't magically conjure GT anyway (no input to spend!)
+                        -- do we need to check this, really?
+                        zero #<= pfromData newStakeDatum.stakedAmount
+                      ]
+              let expectedValue = paddValue # continuingValue # (pdiscreteValue' stake.gtClassRef # delta)
+
+              -- TODO: Same as above. This is quite inefficient now, as it does two lookups
+              -- instead of a more efficient single pass,
+              -- but it doesn't really matter for this. At least it's correct.
+              let valueCorrect =
+                    foldr1
+                      (#&&)
+                      [ pgeqByClass' (AssetClass ("", "")) # value # expectedValue
+                      , pgeqByClass' (untag stake.gtClassRef)
+                          # value
+                          # expectedValue
+                      , pgeqBySymbol
+                          # stCurrencySymbol
+                          # value
+                          # expectedValue
+                      ]
+
+              foldr1
+                (#&&)
+                [ ptraceIfFalse "isScriptAddress" isScriptAddress
+                , ptraceIfFalse "correctOutputDatum" correctOutputDatum
+                , ptraceIfFalse "valueCorrect" valueCorrect
+                ]
+
+        popaque (pconstant ())

--- a/agora/Agora/Stake/Scripts.hs
+++ b/agora/Agora/Stake/Scripts.hs
@@ -65,7 +65,10 @@ import Prelude hiding (Num (..))
    - Check that exactly one state thread is burned.
    - Check that datum at state thread is valid and not locked.
 -}
-stakePolicy :: Tagged GTTag AssetClass -> ClosedTerm PMintingPolicy
+stakePolicy ::
+  -- | The (governance) token that a Stake can store.
+  Tagged GTTag AssetClass ->
+  ClosedTerm PMintingPolicy
 stakePolicy gtClassRef =
   plam $ \_redeemer ctx' -> P.do
     ctx <- pletFields @'["txInfo", "purpose"] ctx'
@@ -157,7 +160,59 @@ stakePolicy gtClassRef =
 
 --------------------------------------------------------------------------------
 
--- | Validator intended for Stake UTXOs to live in.
+-- | Validator intended for Stake UTXOs to be locked by.
+--
+--
+-- == What this Validator does:
+--
+-- === 'DepositWithdraw'
+--
+-- Deposit or withdraw some GT to the stake.
+--
+-- - Tx must be signed by the owner.
+-- - The 'stakedAmount' field must be updated.
+-- - The stake must not be locked.
+-- - The new UTXO must have the previous value plus the difference
+--   as stated by the redeemer.
+--
+-- === 'PermitVote'
+--
+-- Allow a 'ProposalLock' to be put on the stake in order to vote
+-- on a proposal.
+--
+-- - A proposal token must be spent alongside the stake.
+--
+--   * Its total votes must be correctly updated to include this stake's
+--     contribution.
+--
+-- - Tx must be signed by the owner.
+--
+--
+-- === 'RetractVotes'
+--
+-- Remove a 'ProposalLock' set when voting on a proposal.
+--
+-- - A proposal token must be spent alongside the stake.
+-- - Tx must be signed by the owner.
+--
+--
+-- === 'Destroy'
+--
+-- Destroy the stake in order to reclaim the min ADA.
+--
+-- - The stake must not be locked.
+-- - Tx must be signed by the owner.
+--
+--
+-- === 'WitnessStake'
+--
+-- Allow this Stake to be included in a transaction without making
+-- any changes to it. In the future,
+-- this could use [CIP-31](https://cips.cardano.org/cips/cip31/) instead.
+--
+-- - Tx must be signed by the owner __or__ a proposal ST token must be spent
+--   alongside the stake.
+-- - The datum and value must remain unchanged.
 stakeValidator :: Stake -> ClosedTerm PValidator
 stakeValidator stake =
   plam $ \datum redeemer ctx' -> P.do
@@ -243,8 +298,6 @@ stakeValidator stake =
           "Owner signs this transaction"
           ownerSignsTransaction
 
-        passert "ST at inputs must be 1" $
-          spentST #== 1
 
         -- This puts trust into the Proposal. The Proposal must necessarily check
         -- that this is not abused.

--- a/agora/Agora/Stake/Scripts.hs
+++ b/agora/Agora/Stake/Scripts.hs
@@ -160,59 +160,56 @@ stakePolicy gtClassRef =
 
 --------------------------------------------------------------------------------
 
--- | Validator intended for Stake UTXOs to be locked by.
---
---
--- == What this Validator does:
---
--- === 'DepositWithdraw'
---
--- Deposit or withdraw some GT to the stake.
---
--- - Tx must be signed by the owner.
--- - The 'stakedAmount' field must be updated.
--- - The stake must not be locked.
--- - The new UTXO must have the previous value plus the difference
---   as stated by the redeemer.
---
--- === 'PermitVote'
---
--- Allow a 'ProposalLock' to be put on the stake in order to vote
--- on a proposal.
---
--- - A proposal token must be spent alongside the stake.
---
---   * Its total votes must be correctly updated to include this stake's
---     contribution.
---
--- - Tx must be signed by the owner.
---
---
--- === 'RetractVotes'
---
--- Remove a 'ProposalLock' set when voting on a proposal.
---
--- - A proposal token must be spent alongside the stake.
--- - Tx must be signed by the owner.
---
---
--- === 'Destroy'
---
--- Destroy the stake in order to reclaim the min ADA.
---
--- - The stake must not be locked.
--- - Tx must be signed by the owner.
---
---
--- === 'WitnessStake'
---
--- Allow this Stake to be included in a transaction without making
--- any changes to it. In the future,
--- this could use [CIP-31](https://cips.cardano.org/cips/cip31/) instead.
---
--- - Tx must be signed by the owner __or__ a proposal ST token must be spent
---   alongside the stake.
--- - The datum and value must remain unchanged.
+{- | Validator intended for Stake UTXOs to be locked by.
+
+== What this Validator does:
+
+=== 'DepositWithdraw'
+
+Deposit or withdraw some GT to the stake.
+
+- Tx must be signed by the owner.
+- The 'stakedAmount' field must be updated.
+- The stake must not be locked.
+- The new UTXO must have the previous value plus the difference
+  as stated by the redeemer.
+
+=== 'PermitVote'
+
+Allow a 'ProposalLock' to be put on the stake in order to vote
+on a proposal.
+
+- A proposal token must be spent alongside the stake.
+
+  * Its total votes must be correctly updated to include this stake's
+    contribution.
+
+- Tx must be signed by the owner.
+
+=== 'RetractVotes'
+
+Remove a 'ProposalLock' set when voting on a proposal.
+
+- A proposal token must be spent alongside the stake.
+- Tx must be signed by the owner.
+
+=== 'Destroy'
+
+Destroy the stake in order to reclaim the min ADA.
+
+- The stake must not be locked.
+- Tx must be signed by the owner.
+
+=== 'WitnessStake'
+
+Allow this Stake to be included in a transaction without making
+any changes to it. In the future,
+this could use [CIP-31](https://cips.cardano.org/cips/cip31/) instead.
+
+- Tx must be signed by the owner __or__ a proposal ST token must be spent
+  alongside the stake.
+- The datum and value must remain unchanged.
+-}
 stakeValidator :: Stake -> ClosedTerm PValidator
 stakeValidator stake =
   plam $ \datum redeemer ctx' -> P.do
@@ -297,7 +294,6 @@ stakeValidator stake =
         passert
           "Owner signs this transaction"
           ownerSignsTransaction
-
 
         -- This puts trust into the Proposal. The Proposal must necessarily check
         -- that this is not abused.

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -23,7 +23,6 @@ import Plutus.V1.Ledger.Value (CurrencySymbol)
 
 import Agora.AuthorityToken (singleAuthorityTokenBurned)
 import Agora.Utils (passert)
-import Plutarch (popaque)
 import Plutarch.Api.V1 (PValidator)
 import Plutarch.Unsafe (punsafeCoerce)
 

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -29,8 +29,10 @@ import PlutusTx qualified
 
 --------------------------------------------------------------------------------
 
+-- | Redeemer for Treasury actions.
 data TreasuryRedeemer
-  = SpendTreasuryGAT
+  = -- | Allow transaction to pass by delegating to GAT burn.
+    SpendTreasuryGAT
   deriving stock (Eq, Show, GHC.Generic)
 
 PlutusTx.makeIsDataIndexed

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 {- |
 Module: Agora.Treasury
 Maintainer: jack@mlabs.city
@@ -8,23 +10,58 @@ treasury.
 -}
 module Agora.Treasury (module Agora.Treasury) where
 
+import Agora.AuthorityToken (singleAuthorityTokenBurned)
+import Agora.Utils (passert)
 import GHC.Generics qualified as GHC
 import Generics.SOP
+import Plutarch.Api.V1 (PValidator)
 import Plutarch.Api.V1.Contexts (PScriptPurpose (PMinting))
-import Plutarch.Api.V1.Value (PCurrencySymbol, PValue)
+import Plutarch.Api.V1.Value (PValue)
 import Plutarch.DataRepr (
-  PDataFields,
+  DerivePConstantViaData (..),
   PIsDataReprInstances (PIsDataReprInstances),
  )
+import Plutarch.Lift (PConstantDecl (..), PLifted (..), PUnsafeLiftDecl)
 import Plutarch.Monadic qualified as P
+import Plutarch.TryFrom (PTryFrom, ptryFrom)
 import Plutus.V1.Ledger.Value (CurrencySymbol)
+import PlutusTx qualified
 
 --------------------------------------------------------------------------------
 
-import Agora.AuthorityToken (singleAuthorityTokenBurned)
-import Agora.Utils (passert)
-import Plutarch.Api.V1 (PValidator)
-import Plutarch.Unsafe (punsafeCoerce)
+data TreasuryRedeemer
+  = SpendTreasuryGAT
+  deriving stock (Eq, Show, GHC.Generic)
+
+PlutusTx.makeIsDataIndexed
+  ''TreasuryRedeemer
+  [ ('SpendTreasuryGAT, 0)
+  ]
+
+--------------------------------------------------------------------------------
+
+{- | Plutarch level type representing valid redeemers of the
+     treasury.
+-}
+newtype PTreasuryRedeemer (s :: S)
+  = -- | Alters treasury parameters, subject to the burning of a
+    --   governance authority token.
+    PSpendTreasuryGAT (Term s (PDataRecord '[]))
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic, PIsDataRepr)
+  deriving
+    (PlutusType, PIsData)
+    via PIsDataReprInstances PTreasuryRedeemer
+
+deriving via
+  PAsData (PIsDataReprInstances PTreasuryRedeemer)
+  instance
+    PTryFrom PData (PAsData PTreasuryRedeemer)
+
+instance PUnsafeLiftDecl PTreasuryRedeemer where type PLifted PTreasuryRedeemer = TreasuryRedeemer
+deriving via (DerivePConstantViaData TreasuryRedeemer PTreasuryRedeemer) instance (PConstantDecl TreasuryRedeemer)
+
+--------------------------------------------------------------------------------
 
 {- | Validator ensuring that transactions consuming the treasury
      do so in a valid manner.
@@ -32,12 +69,8 @@ import Plutarch.Unsafe (punsafeCoerce)
 treasuryValidator ::
   CurrencySymbol ->
   ClosedTerm PValidator
-treasuryValidator gatCs' = plam $ \datum redeemer ctx' -> P.do
-  -- TODO: Use PTryFrom
-  let treasuryRedeemer :: Term _ (PAsData PTreasuryRedeemer)
-      treasuryRedeemer = punsafeCoerce redeemer
-      _treasuryDatum' :: Term _ (PAsData PTreasuryDatum)
-      _treasuryDatum' = punsafeCoerce datum
+treasuryValidator gatCs' = plam $ \_datum redeemer ctx' -> P.do
+  (treasuryRedeemer, _) <- ptryFrom redeemer
 
   -- plet required fields from script context.
   ctx <- pletFields @["txInfo", "purpose"] ctx'
@@ -46,7 +79,7 @@ treasuryValidator gatCs' = plam $ \datum redeemer ctx' -> P.do
   PMinting _ <- pmatch ctx.purpose
 
   -- Ensure redeemer type is valid.
-  PAlterTreasuryParams _ <- pmatch $ pfromData treasuryRedeemer
+  PSpendTreasuryGAT _ <- pmatch $ pfromData treasuryRedeemer
 
   -- Get the minted value from txInfo.
   txInfo' <- plet ctx.txInfo
@@ -59,37 +92,3 @@ treasuryValidator gatCs' = plam $ \datum redeemer ctx' -> P.do
   passert "A single authority token has been burned" $ singleAuthorityTokenBurned gatCs txInfo' mint
 
   popaque $ pconstant ()
-
-{- | Plutarch level type representing datum of the treasury.
-     Contains:
-
-       - @stateThread@ representing the asset class of the
-         treasury's state thread token.
--}
-newtype PTreasuryDatum (s :: S)
-  = PTreasuryDatum
-      ( Term
-          s
-          ( PDataRecord
-              '[ "stateThread" ':= PCurrencySymbol
-               ]
-          )
-      )
-  deriving stock (GHC.Generic)
-  deriving anyclass (Generic, PIsDataRepr)
-  deriving
-    (PlutusType, PIsData, PDataFields)
-    via PIsDataReprInstances PTreasuryDatum
-
-{- | Plutarch level type representing valid redeemers of the
-     treasury.
--}
-newtype PTreasuryRedeemer (s :: S)
-  = -- | Alters treasury parameters, subject to the burning of a
-    --   governance authority token.
-    PAlterTreasuryParams (Term s (PDataRecord '[]))
-  deriving stock (GHC.Generic)
-  deriving anyclass (Generic, PIsDataRepr)
-  deriving
-    (PlutusType, PIsData)
-    via PIsDataReprInstances PTreasuryRedeemer

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -287,7 +287,11 @@ pfindTxInByTxOutRef = phoistAcyclic $
 pnotNull :: forall list a. PIsListLike list a => Term _ (list a :--> PBool)
 pnotNull = phoistAcyclic $ plam $ pelimList (\_ _ -> pcon PTrue) (pcon PFalse)
 
--- | Check if a particular asset class has been spent in the input list.
+{- | Check if a particular asset class has been spent in the input list.
+
+     When using this as an authority check, you __MUST__ ensure the authority
+     knows how to ensure its end of the contract.
+-}
 ptokenSpent :: forall {s :: S}. Term s (PAssetClass :--> PBuiltinList (PAsData PTxInInfo) :--> PBool)
 ptokenSpent =
   plam $ \tokenClass inputs ->

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -80,7 +80,7 @@ pfindDatum :: Term s (PDatumHash :--> PTxInfo :--> PMaybe PDatum)
 pfindDatum = phoistAcyclic $
   plam $ \datumHash txInfo'' -> P.do
     PTxInfo txInfo' <- pmatch txInfo''
-    plookupTuple # datumHash #$ pfield @"data" # txInfo'
+    plookupTuple # datumHash #$ pfield @"datums" # txInfo'
 
 {- | Find a datum with the given hash.
 NOTE: this is unsafe in the sense that, if the data layout is wrong, this is UB.

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -27,6 +27,7 @@ module Agora.Utils (
   pnotNull,
   pisJust,
   ptokenSpent,
+  pkeysEqual,
 
   -- * Functions which should (probably) not be upstreamed
   anyOutput,
@@ -68,6 +69,7 @@ import Plutarch.Api.V1.Extra (PAssetClass, passetClassValueOf, pvalueOf)
 import Plutarch.Api.V1.Value (PValue (PValue))
 import Plutarch.Builtin (ppairDataBuiltin)
 import Plutarch.Internal (punsafeCoerce)
+import Plutarch.Map.Extra (pkeys)
 import Plutarch.Monadic qualified as P
 import Plutarch.TryFrom (PTryFrom, ptryFrom)
 
@@ -316,6 +318,17 @@ ptokenSpent =
           )
         # 0
         # inputs
+
+{- | True if both maps have exactly the same keys.
+     Using @'#=='@ is not sufficient, because keys returned are not ordered.
+-}
+pkeysEqual :: forall (s :: S) k a b. Term s (PMap k a :--> PMap k b :--> PBool)
+pkeysEqual = phoistAcyclic $
+  plam $ \p q -> P.do
+    pks <- plet $ pkeys # p
+    qks <- plet $ pkeys # q
+    pall # plam (\pk -> pelem # pk # qks) # pks
+      #&& pall # plam (\qk -> pelem # qk # pks) # qks
 
 --------------------------------------------------------------------------------
 {- Functions which should (probably) not be upstreamed

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -36,6 +36,7 @@ module Agora.Utils (
   scriptHashFromAddress,
   findOutputsToAddress,
   findTxOutDatum,
+  validatorHashToTokenName,
 ) where
 
 --------------------------------------------------------------------------------
@@ -53,7 +54,7 @@ import Plutarch.Api.V1 (
   PMap,
   PMaybeData (PDJust),
   PPubKeyHash,
-  PTokenName,
+  PTokenName (PTokenName),
   PTuple,
   PTxInInfo (PTxInInfo),
   PTxInfo,
@@ -430,3 +431,6 @@ findTxOutDatum = phoistAcyclic $
     case datumHash' of
       PDJust ((pfield @"_0" #) -> datumHash) -> pfindDatum # datumHash # datums
       _ -> pcon PNothing
+
+validatorHashToTokenName :: forall (s :: S). Term s PValidatorHash -> Term s PTokenName
+validatorHashToTokenName vh = pcon (PTokenName (pto vh))

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -415,7 +415,8 @@ ptokenSpent =
   plam $ \tokenClass inputs ->
     0
       #< pfoldr @PBuiltinList
-        # ( plam $ \txInInfo' acc -> P.do
+        # plam
+          ( \txInInfo' acc -> P.do
               PTxInInfo txInInfo <- pmatch (pfromData txInInfo')
               PTxOut txOut' <- pmatch $ pfromData $ pfield @"resolved" # txInInfo
               txOut <- pletFields @'["value"] txOut'

--- a/agora/PPrelude.hs
+++ b/agora/PPrelude.hs
@@ -11,8 +11,7 @@ module PPrelude (
   module Plutarch,
 ) where
 
--- NOTE: These are not exported by Plutarch.Prelude, for some reason.
--- Maybe we can 'fix' this upstream?
-import Plutarch (ClosedTerm, POpaque, compile)
+-- 'compile' is not exported by Plutarch.Prelude.
+import Plutarch (compile)
 import Plutarch.Prelude
 import Prelude

--- a/docs/tech-design/proposals.md
+++ b/docs/tech-design/proposals.md
@@ -35,9 +35,9 @@ Initiating a proposal requires the proposer to have more than a certain amount o
 
 ### Voting stages
 
-The life-cycle of a proposal is neatly represented by a state machine, with the 'draft' phase being the initial state, and 'executed' and 'failed' being the terminating states.
+The life-cycle of a proposal is neatly represented by a state machine, with the 'draft' state being the initial state, and 'executed' and 'failed' being the terminating states.
 
-**Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.** This is because some state transitions in the state machine representation don't need to happen in the actual implementation as a transaction. A key example is going from the "lock" phase to the "execution" phase. The only thing that needs to happen is that time goes by. So under the hood, they are represented the same in the Proposal's datum.
+**Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.** This is because some state transitions in the state machine representation don't need to happen in the actual implementation as a transaction. A key example is going from the "lock" phase to the "execution" phase. The only thing that needs to happen is that time goes by. So under the hood, they are represented the same in the Proposal's datum. Furthermore, in order to make our wording consistent, we use _"period"_ to mean a time-based, and _"status"_ to mean what is encoded in the datum. "State", then, refers to the more vague notion of what the state machine would look like.
 
 > Emily 2022-04-27: This is quite confusing still, I feel. @Jack, could you try to reword this and make it more clear?
 
@@ -54,21 +54,21 @@ Consider the following 'stages' of a proposal:
 -   `L`: the length of the locking period.
 -   `E`: the length of the execution period.
 
-| Action                              | Valid POSIXTimeRange                | Valid _stored_ state(s) |
-|-------------------------------------|-------------------------------------|-------------------------|
-| Witness                             | \[S, ∞)                             | \*                      |
-| Cosign                              | \[S, S + D)                         | Draft                   |
-| AdvanceProposal                     | \[S, S + D)                         | Draft                   |
-| Vote                                | \[S + D, S + D + V)                 | Voting                  |
-| Unlock                              | \[S + D, ∞)                         | \*                      |
-| CountVotes                          | \[S + D + V, S + D + V + L)         | Voting                  |
-| ExecuteProposal (if quorum reached) | \[S + D + V + L, S + D + V + L + E) | Voting                  |
+| Action                              | Valid POSIXTimeRange                | Valid _stored_ status(es) |
+|-------------------------------------|-------------------------------------|---------------------------|
+| Witness                             | \[S, ∞)                             | \*                        |
+| Cosign                              | \[S, S + D)                         | Draft                     |
+| AdvanceProposal                     | \[S, S + D)                         | Draft                     |
+| Vote                                | \[S + D, S + D + V)                 | Voting                    |
+| Unlock                              | \[S + D, ∞)                         | \*                        |
+| CountVotes                          | \[S + D + V, S + D + V + L)         | Voting                    |
+| ExecuteProposal (if quorum reached) | \[S + D + V + L, S + D + V + L + E) | Voting                    |
 
 > Jack 2022-02-02: I will consider revising this table further at a later time.
 
 #### Draft phase
 
-During the draft phase, a new UTXO at the proposal script  has been created. At this stage, only votes in favor of co-signing the draft are counted. For the proposal to transition to the voting phase, a threshold of GT will have to be staked backing the proposal. This threshold will be determined on a per-system basis and could itself be a 'governable' parameter. It's important to note that cosignatures are not locking votes. Cosignatures are more like a delegated approval to a proposal. The sum of all cosignatures must tally to the threshold, and all cosigner stake datums must fit into a single transaction to witness their size.
+During the draft phase, a new UTXO at the proposal script  has been created. At this stage, only votes in favor of co-signing the draft are counted. For the proposal to transition to the voting phase, a threshold of GT will have to be staked backing the proposal. This threshold will be determined on a per-system basis and could itself be a 'governable' parameter. It's important to note that cosignatures are not locking votes. Cosignatures are more like a delegated approval to a proposal. The sum of all cosignatures must tally to the threshold, and all cosigner stake datums must fit into a single transaction to witness their size. A limit on the maximum amount of cosigners is placed in order to prevent a situation where the stake datums no longer fit in the transaction. The number doesn't matter and may be expressed in a parametrized way.
 
 #### Voting phase
 

--- a/docs/tech-design/proposals.md
+++ b/docs/tech-design/proposals.md
@@ -4,7 +4,7 @@ This document gives an overview of the technical design of the proposals system 
 
 | Specification | Implementation | Last revision |
 |:-----------:|:-----------:|:-------------:|
-| WIP         |  WIP        | v0.1 2022-04-11    |
+| WIP         |  WIP        | v0.1 2022-04-27    |
 
 ---
 
@@ -35,7 +35,12 @@ Initiating a proposal requires the proposer to have more than a certain amount o
 
 ### Voting stages
 
-The life-cycle of a proposal is neatly represented by a state machine, with the 'draft' phase being the initial state, and 'executed' and 'failed' being the terminating states. Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.
+The life-cycle of a proposal is neatly represented by a state machine, with the 'draft' phase being the initial state, and 'executed' and 'failed' being the terminating states.
+
+**Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.** This is because some state transitions in the state machine representation don't need to happen in the actual implementation as a transaction. A key example is going from the "lock" phase to the "execution" phase. The only thing that needs to happen is that time goes by. So under the hood, they are represented the same in the Proposal's datum.
+
+> Emily 2022-04-27: This is quite confusing still, I feel. @Jack, could you try to reword this and make it more clear?
+
 
 ![](../diagrams/ProposalStateMachine.svg)
 

--- a/docs/tech-design/proposals.md
+++ b/docs/tech-design/proposals.md
@@ -37,38 +37,29 @@ Initiating a proposal requires the proposer to have more than a certain amount o
 
 The life-cycle of a proposal is neatly represented by a state machine, with the 'draft' state being the initial state, and 'executed' and 'failed' being the terminating states.
 
-**Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.** This is because some state transitions in the state machine representation don't need to happen in the actual implementation as a transaction. A key example is going from the "lock" phase to the "execution" phase. The only thing that needs to happen is that time goes by. So under the hood, they are represented the same in the Proposal's datum. Furthermore, in order to make our wording consistent, we use _"period"_ to mean a time-based, and _"status"_ to mean what is encoded in the datum. "State", then, refers to the more vague notion of what the state machine would look like.
+Note: this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.
+**Please note that this state-machine representation is purely conceptual and should not be expected to reflect technical implementation.** This is because some transitions in the state machine representation don't need to happen on-chain, as a transaction. A key example of this is a proposal going from the "lock" phase to the "execution" phase. No on-chain transition takes place: it is simply that we have reached the time in the real-world, when the proposal is allowed to be executed.
 
-> Emily 2022-04-27: This is quite confusing still, I feel. @Jack, could you try to reword this and make it more clear?
+To make the following diagram clear, we employ the following terminology:
+
+
+> state
+> A 'state' in our conceptual FSM representation above. Useful for thinking about proposals. Does not necessarily reflect a change occurring on-chain.
+
+
+> period
+> A segment of real-world, POSIX time. As we transition from one period to another, a proposal's status (see below) will not be updated.
+
+
+> status
+> The 'status' of a proposal is stored in the proposal's datum and is thus always represented on-chain. Changing this requires a transaction to take place.
 
 
 ![](../diagrams/ProposalStateMachine.svg)
 
-#### When may interactions occur?
-
-Consider the following 'stages' of a proposal:
-
--   `S`: when the proposal was created.
--   `D`: the length of the draft period.
--   `V`: the length of the voting period.
--   `L`: the length of the locking period.
--   `E`: the length of the execution period.
-
-| Action                              | Valid POSIXTimeRange                | Valid _stored_ status(es) |
-|-------------------------------------|-------------------------------------|---------------------------|
-| Witness                             | \[S, ∞)                             | \*                        |
-| Cosign                              | \[S, S + D)                         | Draft                     |
-| AdvanceProposal                     | \[S, S + D)                         | Draft                     |
-| Vote                                | \[S + D, S + D + V)                 | Voting                    |
-| Unlock                              | \[S + D, ∞)                         | \*                        |
-| CountVotes                          | \[S + D + V, S + D + V + L)         | Voting                    |
-| ExecuteProposal (if quorum reached) | \[S + D + V + L, S + D + V + L + E) | Voting                    |
-
-> Jack 2022-02-02: I will consider revising this table further at a later time.
-
 #### Draft phase
 
-During the draft phase, a new UTXO at the proposal script  has been created. At this stage, only votes in favor of co-signing the draft are counted. For the proposal to transition to the voting phase, a threshold of GT will have to be staked backing the proposal. This threshold will be determined on a per-system basis and could itself be a 'governable' parameter. It's important to note that cosignatures are not locking votes. Cosignatures are more like a delegated approval to a proposal. The sum of all cosignatures must tally to the threshold, and all cosigner stake datums must fit into a single transaction to witness their size. A limit on the maximum amount of cosigners is placed in order to prevent a situation where the stake datums no longer fit in the transaction. The number doesn't matter and may be expressed in a parametrized way.
+During the draft phase, a new UTXO at the proposal script  has been created. At this stage, only votes in favor of co-signing the draft are counted. For the proposal to transition to the voting phase, a threshold of GT will have to be staked backing the proposal. This threshold will be determined on a per-system basis and could itself be a 'governable' parameter. It's important to note that cosignatures are not locking votes. Cosignatures are more like a delegated approval to a proposal. The sum of all cosignatures must tally to the threshold, and all cosigner stake datums must fit into a single transaction to witness their size. A limit on the maximum amount of cosigners is placed in order to prevent a situation where the stake datums no longer fit in the transaction. The number doesn't matter and may be expressed in a parameterized way.
 
 #### Voting phase
 

--- a/flake.lock
+++ b/flake.lock
@@ -1621,17 +1621,17 @@
         "validity": "validity"
       },
       "locked": {
-        "lastModified": 1648639396,
-        "narHash": "sha256-pAkEsIDXJckVYufVPUzD/4sq4/uE7iyV0IR2BuLhZjY=",
+        "lastModified": 1650025193,
+        "narHash": "sha256-SXfkWYse308SdnWO34cMVjKliDvyYYx++Y5uiuUmGXE=",
         "owner": "peter-mlabs",
         "repo": "plutarch",
-        "rev": "a7a410da209b9c14c834a41e07b1c197c2a4dcd6",
+        "rev": "18e787d420912ed765fc5653c3558f20ab5e638a",
         "type": "github"
       },
       "original": {
         "owner": "peter-mlabs",
         "repo": "plutarch",
-        "rev": "a7a410da209b9c14c834a41e07b1c197c2a4dcd6",
+        "rev": "18e787d420912ed765fc5653c3558f20ab5e638a",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -117,23 +117,6 @@
         "type": "github"
       }
     },
-    "autodocodec": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644358110,
-        "narHash": "sha256-X1TNZlmO2qDFk3OL4Z1v/gzvd3ouoACAiMweutsYek4=",
-        "owner": "srid",
-        "repo": "autodocodec",
-        "rev": "42b42a7407f33c6c74fa4e8c84906aebfed28daf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "ghc921",
-        "repo": "autodocodec",
-        "type": "github"
-      }
-    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -463,21 +446,6 @@
         "type": "github"
       }
     },
-    "flake-compat-ci_3": {
-      "locked": {
-        "lastModified": 1641672839,
-        "narHash": "sha256-Bdwv+DKeEMlRNPDpZxSz0sSrqQBvdKO5fZ8LmvrgCOU=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e832114bc18376c0f3fa13c19bf5ff253cc6570a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
     "flake-compat_2": {
       "flake": false,
       "locked": {
@@ -497,22 +465,6 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
         "lastModified": 1606424373,
         "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
         "owner": "edolstra",
@@ -527,7 +479,7 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1606424373,
@@ -981,7 +933,7 @@
     },
     "hercules-ci-agent": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_4",
         "nix-darwin": "nix-darwin",
         "nixos-20_09": "nixos-20_09",
         "nixos-unstable": "nixos-unstable",
@@ -1004,7 +956,7 @@
     },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_3",
         "hercules-ci-agent": "hercules-ci-agent",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-nixops": "nixpkgs-nixops"
@@ -1085,6 +1037,55 @@
         "owner": "vincenthz",
         "repo": "hs-memory",
         "rev": "3cf661a8a9a8ac028df77daa88e8d65c55a3347a",
+        "type": "github"
+      }
+    },
+    "hspec": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1649095108,
+        "narHash": "sha256-cPmt4hvmdh727VT6UAL8yFArmm4FAWeg3K5Qi3XtU4g=",
+        "owner": "srid",
+        "repo": "hspec",
+        "rev": "44f2a143e10c93df237af428457d0e4b74ae270a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "askAncestors",
+        "repo": "hspec",
+        "type": "github"
+      }
+    },
+    "hspec-golden": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648755064,
+        "narHash": "sha256-5a6BksZx00o2iL0Ei/L1Kkou2BsnsIagN+tTmqYyKfs=",
+        "owner": "stackbuilders",
+        "repo": "hspec-golden",
+        "rev": "4b0ad56b2de0254a7b1e0feda917656f78a5bcda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stackbuilders",
+        "repo": "hspec-golden",
+        "type": "github"
+      }
+    },
+    "hspec-hedgehog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1602603478,
+        "narHash": "sha256-XnS3zjQ7eh3iBOWq+Z/YcwrfWI55hV6k8LsZ8qm/qOc=",
+        "owner": "parsonsmatt",
+        "repo": "hspec-hedgehog",
+        "rev": "eb617d854542510f0129acdea4bf52e50b13042e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "parsonsmatt",
+        "repo": "hspec-hedgehog",
         "type": "github"
       }
     },
@@ -1592,19 +1593,24 @@
     "plutarch": {
       "inputs": {
         "Shrinker": "Shrinker",
-        "autodocodec": "autodocodec",
         "cardano-base": "cardano-base",
         "cardano-crypto": "cardano-crypto",
         "cardano-prelude": "cardano-prelude",
         "cryptonite": "cryptonite",
-        "flake-compat": "flake-compat_3",
-        "flake-compat-ci": "flake-compat-ci_3",
+        "emanote": [
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat",
         "foundation": "foundation",
         "haskell-language-server": "haskell-language-server_2",
         "haskell-nix": "haskell-nix_4",
         "hercules-ci-effects": "hercules-ci-effects",
         "hs-memory": "hs-memory",
+        "hspec": "hspec",
+        "hspec-golden": "hspec-golden",
+        "hspec-hedgehog": "hspec-hedgehog",
         "iohk-nix": "iohk-nix_2",
         "nixpkgs": [
           "plutarch",
@@ -1614,24 +1620,21 @@
         "nixpkgs-2111": "nixpkgs-2111_5",
         "plutus": "plutus_2",
         "protolude": "protolude",
-        "safe-coloured-text": "safe-coloured-text",
         "sized-functors": "sized-functors",
-        "sydtest": "sydtest",
-        "th-extras": "th-extras",
-        "validity": "validity"
+        "th-extras": "th-extras"
       },
       "locked": {
-        "lastModified": 1650025193,
-        "narHash": "sha256-SXfkWYse308SdnWO34cMVjKliDvyYYx++Y5uiuUmGXE=",
+        "lastModified": 1650382454,
+        "narHash": "sha256-b31DK+E/0MtR45+Z+F5U1E8jjcewvZ42UmFLZlXDAYM=",
         "owner": "peter-mlabs",
         "repo": "plutarch",
-        "rev": "18e787d420912ed765fc5653c3558f20ab5e638a",
+        "rev": "6ef18aacd02050fc07398e399cff5e8734c1045e",
         "type": "github"
       },
       "original": {
         "owner": "peter-mlabs",
         "repo": "plutarch",
-        "rev": "18e787d420912ed765fc5653c3558f20ab5e638a",
+        "rev": "6ef18aacd02050fc07398e399cff5e8734c1045e",
         "type": "github"
       }
     },
@@ -1771,23 +1774,6 @@
         "plutarch": "plutarch"
       }
     },
-    "safe-coloured-text": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644357337,
-        "narHash": "sha256-sXSKw8m6O9K/H2BBiYqO5e4sJIo+9UP+UvEukRn28d8=",
-        "owner": "srid",
-        "repo": "safe-coloured-text",
-        "rev": "034f3612525568b422e0c62b52417d77b7cf31c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "ghc921",
-        "repo": "safe-coloured-text",
-        "type": "github"
-      }
-    },
     "sized-functors": {
       "flake": false,
       "locked": {
@@ -1917,23 +1903,6 @@
         "type": "github"
       }
     },
-    "sydtest": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645114028,
-        "narHash": "sha256-P6ZwwfFeN8fpi3fziz9yERTn7BfxdE/j/OofUu+4GdA=",
-        "owner": "srid",
-        "repo": "sydtest",
-        "rev": "9c6c7678f7aabe22e075aab810a6a2e304591d24",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "ghc921",
-        "repo": "sydtest",
-        "type": "github"
-      }
-    },
     "th-extras": {
       "flake": false,
       "locked": {
@@ -1948,23 +1917,6 @@
         "owner": "mokus0",
         "repo": "th-extras",
         "rev": "787ed752c1e5d41b5903b74e171ed087de38bffa",
-        "type": "github"
-      }
-    },
-    "validity": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644358698,
-        "narHash": "sha256-dpMIu08qXMzy8Kilk/2VWpuwIsfqFtpg/3mkwt5pdjA=",
-        "owner": "srid",
-        "repo": "validity",
-        "rev": "f7982549b95d0ab727950dc876ca06b1862135ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "ghc921",
-        "repo": "validity",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
 
   # Rev is this PR https://github.com/peter-mlabs/plutarch/pull/5.
   inputs.plutarch.url =
-    "github:peter-mlabs/plutarch?rev=a7a410da209b9c14c834a41e07b1c197c2a4dcd6";
+    "github:peter-mlabs/plutarch?rev=18e787d420912ed765fc5653c3558f20ab5e638a";
   inputs.plutarch.inputs.nixpkgs.follows =
     "plutarch/haskell-nix/nixpkgs-unstable";
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,10 @@
   # see https://github.com/NixOS/nix/issues/6013
   inputs.nixpkgs-2111 = { url = "github:NixOS/nixpkgs/nixpkgs-21.11-darwin"; };
 
-  # Rev is this PR https://github.com/peter-mlabs/plutarch/pull/5.
   inputs.plutarch.url =
-    "github:peter-mlabs/plutarch?rev=18e787d420912ed765fc5653c3558f20ab5e638a";
+    "github:peter-mlabs/plutarch?rev=6ef18aacd02050fc07398e399cff5e8734c1045e";
+  inputs.plutarch.inputs.emanote.follows =
+    "plutarch/haskell-nix/nixpkgs-unstable";
   inputs.plutarch.inputs.nixpkgs.follows =
     "plutarch/haskell-nix/nixpkgs-unstable";
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,8 +1,2 @@
 cradle:
   cabal:
-    - path: "./agora"
-      component: "lib:agora"
-    - path: "./agora-bench"
-      component: "benchmark:agora-bench"
-    - path: "./agora-test"
-      component: "test:agora-test"


### PR DESCRIPTION
Will close #5

This PR has grown into a large monster.

In order to make it a little more clear what this adds here's a summary:
- Implemented Agora.Record (utilities for creating records instead of `pdcons` and `pdnil`)
- Made Proposal types more correct
- Added Agora.Proposal.Time module which contains some functions for dealing with time constraints
- Added all missing haddock docstrings
- Implemented proposal policy
- Stubbed out logic for proposal validator
- Added shared testing sample code
- Some minor changes to Stake validator
- Moved Stake and Proposal scripts to submodule

