### PR TITLE
Publish haddock in CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -68,3 +68,36 @@ jobs:
 
       - name: Build the project
         run: nix build .#check.x86_64-linux
+
+
+
+  haddock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+
+    - uses: cachix/install-nix-action@v16
+      name: Set up Nix and IOHK caches
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
+          experimental-features = nix-command flakes
+
+    - uses: cachix/cachix-action@v10
+      with:
+        name: mlabs
+        authToken: ${{ secrets.CACHIX_KEY }}
+
+    - run: nix build .#packages.x86_64-linux.haddock
+      name: Run 'haddock' from flake.nix
+
+    # This publishes the haddock result to the branch 'gh-pages',
+    # which is set to automatically deploy to https://liqwid-labs.github.io/agora/.
+    - name: Publish Documentation
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/master'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./result/agora/html

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Open a development shell with `nix develop` and build the project with `cabal bu
 
 Documentation for Agora may be found in [docs](./docs).
 
+Haddock is deployed on GitHub Pages [here](https://liqwid-labs.github.io/agora/).
+
 ### Using Agora for your protocol
 
 If you are a protocol wanting to use Agora, read [Using Agora](./docs/using-agora.md).


### PR DESCRIPTION
Supersedes #25. 

This essentially makes the haddock docs browsable at https://liqwid-labs.github.io/agora/.

Caveats: Sadly this doesn't make any of the other libraries like plutarch or plutarch-safemoney browsable, which means a lot of things will be dead links. But I think since the goal of this is to have Agora's documentation linkable, it works well for our purposes.