### PR TITLE
Trivial script exporting (+changelog update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+
+## Unreleased (Candidate for 0.2.0)
+
+### Added
+
+- Script exporting with `plutarch-script-export` 
+
+### Modified
+
+- Draft phase and cosigning for Proposals. 
+
+  Included by [#136](https://github.com/Liqwid-Labs/agora/pull/136).
+
+- Fixed bug with regards to moving from `VotingReady`.
+
+  Included by [#134](https://github.com/Liqwid-Labs/agora/pull/134).
+  
+- Fixed bug that made it impossible to create proposals. Added new stake locking mechanism for creating proposals. 
+  
+  Included by [#142](https://github.com/Liqwid-Labs/agora/pull/142).
+  
+  NOTE: This changes the representation of the following types:
+  
+  - `PProposalLock`
+  - `PStakeDatum`
+  - `PStakeRedeemer`
+  - `PProposalRedeemer`
+  - `PTreasuryRedeemer`
+  - `PGovernorDatum`
+
 ## 0.1.0 -- 2022-06-22
 
 ### Added

--- a/agora-scripts/Main.hs
+++ b/agora-scripts/Main.hs
@@ -59,17 +59,20 @@ builders =
     & insertBuilder "proposalValidator" ((.proposalValidatorInfo) . agoraScripts)
     & insertBuilder "treasuryValidator" ((.treasuryValidatorInfo) . agoraScripts)
     & insertBuilder "authorityTokenPolicy" ((.authorityTokenPolicyInfo) . agoraScripts)
-
     -- Trivial scripts. These are useful for testing, but they likely aren't useful
     -- to you if you are actually interested in deploying to mainnet.
-    & insertBuilder "alwaysSucceedsPolicy"
-        (\() -> mkPolicyInfo $ plam $ \_ _ -> popaque (pconstant ()) )
-    & insertBuilder "alwaysSucceedsValidator"
-        (\() -> mkValidatorInfo $ plam $ \_ _ _ -> popaque (pconstant ()) )
-    & insertBuilder "neverSucceedsPolicy"
-        (\() -> mkPolicyInfo $ plam $ \_ _ -> perror )
-    & insertBuilder "neverSucceedsValidator"
-        (\() -> mkValidatorInfo $ plam $ \_ _ _ -> perror )
+    & insertBuilder
+      "alwaysSucceedsPolicy"
+      (\() -> mkPolicyInfo $ plam $ \_ _ -> popaque (pconstant ()))
+    & insertBuilder
+      "alwaysSucceedsValidator"
+      (\() -> mkValidatorInfo $ plam $ \_ _ _ -> popaque (pconstant ()))
+    & insertBuilder
+      "neverSucceedsPolicy"
+      (\() -> mkPolicyInfo $ plam $ \_ _ -> perror)
+    & insertBuilder
+      "neverSucceedsValidator"
+      (\() -> mkValidatorInfo $ plam $ \_ _ _ -> perror)
 
 {- | Create scripts from params.
 

--- a/agora-scripts/Main.hs
+++ b/agora-scripts/Main.hs
@@ -50,6 +50,7 @@ main =
 builders :: Builders
 builders =
   def
+    -- Agora scripts
     & insertBuilder "governorPolicy" ((.governorPolicyInfo) . agoraScripts)
     & insertBuilder "governorValidator" ((.governorValidatorInfo) . agoraScripts)
     & insertBuilder "stakePolicy" ((.stakePolicyInfo) . agoraScripts)
@@ -58,6 +59,17 @@ builders =
     & insertBuilder "proposalValidator" ((.proposalValidatorInfo) . agoraScripts)
     & insertBuilder "treasuryValidator" ((.treasuryValidatorInfo) . agoraScripts)
     & insertBuilder "authorityTokenPolicy" ((.authorityTokenPolicyInfo) . agoraScripts)
+
+    -- Trivial scripts. These are useful for testing, but they likely aren't useful
+    -- to you if you are actually interested in deploying to mainnet.
+    & insertBuilder "alwaysSucceedsPolicy"
+        (\() -> mkPolicyInfo $ plam $ \_ _ -> popaque (pconstant ()) )
+    & insertBuilder "alwaysSucceedsValidator"
+        (\() -> mkValidatorInfo $ plam $ \_ _ _ -> popaque (pconstant ()) )
+    & insertBuilder "neverSucceedsPolicy"
+        (\() -> mkPolicyInfo $ plam $ \_ _ -> perror )
+    & insertBuilder "neverSucceedsValidator"
+        (\() -> mkValidatorInfo $ plam $ \_ _ _ -> perror )
 
 {- | Create scripts from params.
 


### PR DESCRIPTION
Summary:
- Adds 4 trivially simple scripts to export. Useful for creating simple tokens on the testnet, for example. 
- It also adds entries to changelog for unreleased work.