### PR TITLE
Use `liqwid-nix`; Bump plutarch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,12 @@ PS_BRIDGE_OUTPUT_DIR := agora-purescript-bridge/
 ps_bridge:
 	cabal run exe:agora-purescript-bridge -- -o $(PS_BRIDGE_OUTPUT_DIR)
 
+BENCH_OUTPUT = "bench.csv"
 bench:
-	cabal run agora-bench
+	cabal run agora-bench -- -o $(BENCH_OUTPUT)
 
-BENCH_TMPDIR := $(shell mktemp -d)
-BENCH_TMPFILE := $(BENCH_TMPDIR)/bench.csv
 bench_check:
-	(cabal run agora-bench -- -o "$(BENCH_TMPFILE)" \
-		|| $(bench) -o "$(BENCH_TMPFILE)") >> /dev/null
-	diff bench.csv $(BENCH_TMPFILE) \
-		|| (echo "bench.csv is outdated"; exit 1)
-	# TODO: do the clean-up even if `diff` fails.
-	rm -rf $(BENCH_TMPDIR)
+	cabal -v0 new-run agora-bench | diff bench.csv -
 
 scripts:
 	cabal run agora-scripts -- -c

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,32 @@
 # This really ought to be `/usr/bin/env bash`, but nix flakes don't like that.
 SHELL := /bin/sh
 
-.PHONY: hoogle format haddock usage tag format_nix format_haskell format_check lint ps_bridge bench bench_check scripts
+.PHONY: hoogle format haddock usage tag format_nix format_haskell format_check	\ 
+				lint refactor ps_bridge bench bench_check scripts test build ci
 
-AGORA_TARGETS := agora agora-bench agora-purescript-bridge agora-scripts agora-specs agora-test agora-testlib
+SOURCE_FILES := $(shell git ls-tree -r HEAD --full-tree --name-only)
+SOURCE_FILES := $(wildcard $(SOURCE_FILES))
+HASKELL_SOURCES := $(filter %.hs,$(SOURCE_FILES))
+CABAL_SOURCES := $(filter %.cabal,$(SOURCE_FILES))
+NIX_SOURCES := $(filter %.nix,$(SOURCE_FILES))
+FORMAT_EXTENSIONS := -o -XQuasiQuotes -o -XTemplateHaskell -o -XTypeApplications	\
+										-o -XImportQualifiedPost -o -XPatternSynonyms -o -XOverloadedRecordDot
+HLINT_EXTS := -XQuasiQuotes
+
+THREADS ?= 8
+PS_BRIDGE_OUTPUT_DIR ?= agora-purescript-bridge/
+BENCH_OUTPUT ?= bench.csv
+TEST_CASE_TIMEOUT ?= 100
 
 usage:
-	@echo "usage: make <command> [OPTIONS]"
+	@echo "usage: [env [<variable>=<value> ...]] make <command> [OPTIONS]"
 	@echo
+	@echo "Available variables:"
+	@echo "  THREADS -- The number of threads for building the project"
+	@echo "  PS_BRIDGE_OUTPUT_DIR -- The output directory of the purescript bridge"
+	@echo "  BENCH_OUTPUT -- The output file of the benchmark report"
+	@echo "  TEST_CASE_TIMEOUT -- Timeout for individual tests. Default unit: s"
+	@echo 
 	@echo "Available commands:"
 	@echo "  hoogle -- Start local hoogle"
 	@echo "  format -- Format the project"
@@ -21,8 +40,13 @@ usage:
 	@echo "  bench -- Generate bench report bench.csv"
 	@echo "  bench_check -- Check if bench report is up-to-date"
 	@echo "  scripts -- Run the agora script server (dev mode)"
+	@echo "  ci -- Run all the CI checks"
 
-hoogle:
+requires_nix_shell:
+	@ [ "$(IN_NIX_SHELL)" ] || echo "The $(MAKECMDGOALS) target must be run from inside a nix shell"
+	@ [ "$(IN_NIX_SHELL)" ] || (echo "    run 'nix develop' first" && false)
+
+hoogle: requires_nix_shell
 	pkill hoogle || true
 	hoogle generate --local=haddock --database=hoo/local.hoo
 	hoogle server --local -p 8081 >> /dev/null &
@@ -30,39 +54,48 @@ hoogle:
 
 format: format_haskell format_nix
 
-format_nix:
-	git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.nix' | xargs nixpkgs-fmt
+format_nix: requires_nix_shell
+	nixpkgs-fmt $(NIX_SOURCES)
 
-FORMAT_EXTENSIONS := -o -XQuasiQuotes -o -XTemplateHaskell -o -XTypeApplications -o -XImportQualifiedPost -o -XPatternSynonyms -o -XOverloadedRecordDot
-format_haskell:
-	find -name '*.hs' -not -path './dist-*/*' | xargs fourmolu $(FORMAT_EXTENSIONS) -m inplace
-	git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.cabal' | xargs cabal-fmt -i
+format_haskell: requires_nix_shell
+	fourmolu $(FORMAT_EXTENSIONS) -m inplace $(HASKELL_SOURCES)
+	cabal-fmt -i $(CABAL_SOURCES)
 
-format_check:
-	find -name '*.hs' \
-	     -not -path './dist*/*' \
-	     -not -path './haddock/*' \
-	  | xargs fourmolu $(FORMAT_EXTENSIONS) -m check
+format_check: requires_nix_shell
+	fourmolu $(FORMAT_EXTENSIONS) -m check $(HASKELL_SOURCES)
+	nixpkgs-fmt --check $(NIX_SOURCES) 
+	cabal-fmt --check $(CABAL_SOURCES)
 
-haddock:
+haddock: requires_nix_shell
 	cabal haddock --haddock-html --haddock-hoogle --builddir=haddock
 
-tag:
-	hasktags -x $(AGORA_TARGETS)
+tag: requires_nix_shell
+	hasktags -x $(HASKELL_SOURCES)
 
-lint:
-	hlint $(AGORA_TARGETS)
+lint: requires_nix_shell
+	hlint $(HLINT_EXTS) $(HASKELL_SOURCES)
 
-PS_BRIDGE_OUTPUT_DIR := agora-purescript-bridge/
-ps_bridge:
+refactor: requires_nix_shell
+	for src in $(HASKELL_SOURCES) ; do \
+		hlint $(HLINT_EXTS) --refactor --refactor-options='-i -s' $$src ;\
+	done
+
+ps_bridge: requires_nix_shell
 	cabal run exe:agora-purescript-bridge -- -o $(PS_BRIDGE_OUTPUT_DIR)
 
-BENCH_OUTPUT = "bench.csv"
-bench:
+bench: requires_nix_shell
 	cabal run agora-bench -- -o $(BENCH_OUTPUT)
 
-bench_check:
+bench_check: requires_nix_shell
 	cabal -v0 new-run agora-bench | diff bench.csv -
 
-scripts:
+scripts: requires_nix_shell
 	cabal run agora-scripts -- -c
+
+test: requires_nix_shell
+	cabal test --test-options="--hide-successes -t $(TEST_CASE_TIMEOUT) -j$(THREADS)"
+
+build: requires_nix_shell
+	cabal build -j$(THREADS)
+
+ci: format_check lint build bench_check test haddock

--- a/agora-bench/Bench.hs
+++ b/agora-bench/Bench.hs
@@ -8,7 +8,6 @@ import Data.ByteString.Short qualified as SBS
 import Data.Csv (DefaultOrdered, ToNamedRecord, header, headerOrder, namedRecord, toNamedRecord, (.=))
 import Data.List (intercalate)
 import Data.Text (Text, pack)
-import GHC.Generics (Generic)
 import Plutarch.Evaluate (evalScript)
 import PlutusLedgerApi.V1 (
   ExBudget (ExBudget),

--- a/agora-bench/Main.hs
+++ b/agora-bench/Main.hs
@@ -3,10 +3,10 @@ module Main (main) where
 import Bench (specificationTreeToBenchmarks)
 import Data.Csv (EncodeOptions (encUseCrLf), defaultEncodeOptions, encodeDefaultOrderedByNameWith)
 import Data.Text.Lazy.Encoding (decodeUtf8)
-import Data.Text.Lazy.IO as I (writeFile)
+import Data.Text.Lazy.IO as I (putStr, writeFile)
 import Options (Options (..), parseOptions)
 import Prettyprinter (defaultLayoutOptions, layoutPretty, pretty)
-import Prettyprinter.Render.String (renderString)
+import Prettyprinter.Render.Text (renderLazy)
 import Spec.AuthorityToken qualified as AuthorityToken
 import Spec.Effect.GovernorMutation qualified as GovernorMutation
 import Spec.Effect.TreasuryWithdrawal qualified as TreasuryWithdrawal
@@ -14,6 +14,7 @@ import Spec.Governor qualified as Governor
 import Spec.Proposal qualified as Proposal
 import Spec.Stake qualified as Stake
 import Spec.Treasury qualified as Treasury
+import System.IO (hIsTerminalDevice, stdout)
 import Test.Specification (group)
 import Prelude
 
@@ -22,11 +23,14 @@ import Prelude
 main :: IO ()
 main = do
   options <- parseOptions
+  isTTY <- hIsTerminalDevice stdout
 
-  I.writeFile options.output $
-    (decodeUtf8 . encodeDefaultOrderedByNameWith encodeOptions) res
+  mapM_ (`I.writeFile` csv) options.output
 
-  mapM_ (putStrLn . renderString . layoutPretty defaultLayoutOptions . pretty) res
+  I.putStr $
+    if isTTY
+      then prettified
+      else csv
   where
     encodeOptions =
       defaultEncodeOptions
@@ -49,3 +53,7 @@ main = do
           , group "AuthorityToken" AuthorityToken.specs
           , group "Governor" Governor.specs
           ]
+
+    csv = decodeUtf8 $ encodeDefaultOrderedByNameWith encodeOptions res
+
+    prettified = renderLazy $ layoutPretty defaultLayoutOptions $ pretty res

--- a/agora-bench/Options.hs
+++ b/agora-bench/Options.hs
@@ -1,21 +1,22 @@
 module Options (Options (..), parseOptions) where
 
+import Control.Applicative (optional)
 import Options.Applicative ((<**>))
 import Options.Applicative qualified as Opt
 
 newtype Options = Options
-  { output :: FilePath
+  { output :: Maybe FilePath
   }
 
-outputOpt :: Opt.Parser FilePath
+outputOpt :: Opt.Parser (Maybe FilePath)
 outputOpt =
-  Opt.strOption
-    ( Opt.long "output-path"
-        <> Opt.short 'o'
-        <> Opt.metavar "OUTPUT_PATH"
-        <> Opt.value "./bench.csv"
-        <> Opt.help "The path of the bench report file."
-    )
+  optional $
+    Opt.strOption
+      ( Opt.long "output-path"
+          <> Opt.short 'o'
+          <> Opt.metavar "OUTPUT_PATH"
+          <> Opt.help "The path of the bench report file."
+      )
 
 benchOpt :: Opt.Parser Options
 benchOpt = Options <$> outputOpt

--- a/agora-purescript-bridge/AgoraTypes.hs
+++ b/agora-purescript-bridge/AgoraTypes.hs
@@ -31,14 +31,12 @@ agoraTypes =
   , mkSumType (Proxy @Proposal.ProposalVotes)
   , mkSumType (Proxy @Proposal.ProposalDatum)
   , mkSumType (Proxy @Proposal.ProposalRedeemer)
-  , mkSumType (Proxy @Proposal.Proposal)
   , -- Governor
     mkSumType (Proxy @Governor.GovernorDatum)
   , mkSumType (Proxy @Governor.GovernorRedeemer)
   , mkSumType (Proxy @Governor.Governor)
   , -- Stake
-    mkSumType (Proxy @Stake.Stake)
-  , mkSumType (Proxy @Stake.ProposalLock)
+    mkSumType (Proxy @Stake.ProposalLock)
   , mkSumType (Proxy @Stake.StakeRedeemer)
   , mkSumType (Proxy @Stake.StakeDatum)
   , -- Treasury

--- a/agora-scripts/Main.hs
+++ b/agora-scripts/Main.hs
@@ -107,7 +107,12 @@ agoraScripts params =
 
     governorSTAssetClass :: AssetClass
     governorSTAssetClass =
-      Value.assetClass (mintingPolicySymbol $ mkMintingPolicy $ governorPolicy governor) ""
+      Value.assetClass
+        ( mintingPolicySymbol $
+            mkMintingPolicy def $
+              governorPolicy governor
+        )
+        ""
 
     proposal :: Proposal
     proposal = proposalFromGovernor governor

--- a/agora-specs/Property/Generator.hs
+++ b/agora-specs/Property/Generator.hs
@@ -114,8 +114,10 @@ genInput = do
   val <- genSingletonValue
   return $
     input $
-      credential cred
-        . withValue val
+      mconcat
+        [ credential cred
+        , withValue val
+        ]
 
 genOutput :: Builder a => Gen a
 genOutput = do
@@ -123,8 +125,10 @@ genOutput = do
   val <- genSingletonValue
   return $
     output $
-      credential cred
-        . withValue val
+      mconcat
+        [ credential cred
+        , withValue val
+        ]
 
 genOutRef :: Gen TxOutRef
 genOutRef = do

--- a/agora-specs/Property/Governor.hs
+++ b/agora-specs/Property/Governor.hs
@@ -157,7 +157,13 @@ governorMintingProperty =
     -}
     gst = assetClassValue govAssetClass 1
     mintAmount x = mint . mconcat $ replicate x gst
-    outputToGov = output $ script govValidatorHash . withValue gst . withDatum govDatum
+    outputToGov =
+      output $
+        mconcat
+          [ script govValidatorHash
+          , withValue gst
+          , withDatum govDatum
+          ]
     referencedInput = input $ withOutRef gstUTXORef
 
     govDatum :: GovernorDatum

--- a/agora-specs/Property/Governor.hs
+++ b/agora-specs/Property/Governor.hs
@@ -7,7 +7,7 @@ Property model and tests for 'Governor' related functions
 -}
 module Property.Governor (props) where
 
-import Agora.Governor (GovernorDatum (..), pisGovernorDatumValid)
+import Agora.Governor (Governor (gstOutRef), GovernorDatum (..), pisGovernorDatumValid)
 import Agora.Governor.Scripts (governorPolicy)
 import Agora.Proposal (
   ProposalId (ProposalId),
@@ -201,7 +201,7 @@ governorMintingProperty =
     opaqueToUnit = plam $ \_ -> pconstant ()
 
     actual :: Term s (PScriptContext :--> PUnit)
-    actual = plam $ \sc -> opaqueToUnit #$ governorPolicy governor # pforgetData (pconstantData ()) # sc
+    actual = plam $ \sc -> opaqueToUnit #$ governorPolicy governor.gstOutRef # pforgetData (pconstantData ()) # sc
 
     classifier :: ScriptContext -> GovernorPolicyCases
     classifier sc

--- a/agora-specs/Sample/Effect/GovernorMutation.hs
+++ b/agora-specs/Sample/Effect/GovernorMutation.hs
@@ -17,6 +17,7 @@ import Agora.Effect.GovernorMutation (
  )
 import Agora.Governor (GovernorDatum (..))
 import Agora.Proposal (ProposalId (..), ProposalThresholds (..))
+import Agora.Utils (validatorHashToTokenName)
 import Data.Default.Class (Default (def))
 import Data.Tagged (Tagged (..))
 import Plutarch.Api.V1 (mkValidator, validatorHash)
@@ -24,7 +25,6 @@ import PlutusLedgerApi.V1 (
   Address,
   Datum (..),
   ToData (..),
-  TokenName (..),
   TxInInfo (..),
   TxInfo (..),
   TxOut (..),
@@ -40,10 +40,11 @@ import PlutusLedgerApi.V1.Value qualified as Value (
   singleton,
  )
 import Sample.Shared (
+  agoraScripts,
   authorityTokenSymbol,
+  deterministicTracingConfing,
   govAssetClass,
   govValidatorAddress,
-  governor,
   minAda,
   signer,
  )
@@ -51,7 +52,7 @@ import Test.Util (datumPair, toDatumHash)
 
 -- | The effect validator instance.
 effectValidator :: Validator
-effectValidator = mkValidator def $ mutateGovernorValidator governor
+effectValidator = mkValidator deterministicTracingConfing $ mutateGovernorValidator agoraScripts
 
 -- | The hash of the validator instance.
 effectValidatorHash :: ValidatorHash
@@ -65,17 +66,15 @@ effectValidatorAddress = scriptHashAddress effectValidatorHash
 atAssetClass :: AssetClass
 atAssetClass = assetClass authorityTokenSymbol tokenName
   where
-    -- TODO: use 'validatorHashToTokenName'
-    ValidatorHash bs = effectValidatorHash
-    tokenName = TokenName bs
+    tokenName = validatorHashToTokenName effectValidatorHash
 
 -- | The mock reference of the governor state UTXO.
 govRef :: TxOutRef
-govRef = TxOutRef "614481d2159bfb72350222d61fce17e548e0fc00e5a1f841ff1837c431346ce7" 1
+govRef = TxOutRef "1475e1ee22330dfc55430980e5a6b100ec9d9249bb4b462256a79559" 1
 
 -- | The mock reference of the effect UTXO.
 effectRef :: TxOutRef
-effectRef = TxOutRef "c31164dc11835de7eb6187f67d0e1a19c1dfc0786a456923eef5043189cdb578" 1
+effectRef = TxOutRef "a302d327d8e5553d50b9d017475369753f723d7e999ac1b68da8ad52" 1
 
 -- | The input effect datum in 'mkEffectTransaction'.
 mkEffectDatum :: GovernorDatum -> MutateGovernorDatum
@@ -159,7 +158,7 @@ mkEffectTxInfo newGovDatum =
         , txInfoValidRange = Interval.always
         , txInfoSignatories = [signer]
         , txInfoData = datumPair <$> [governorInputDatum, governorOutputDatum, effectInputDatum]
-        , txInfoId = "4dae3806cc69615b721d52ed09b758f43f25a8f39b7934d6b28514caf71f5f7b"
+        , txInfoId = "74c75505691e7baa981fa80e50b9b7e88dbe1eda67d4f062d89d203b"
         }
 
 validNewGovernorDatum :: GovernorDatum

--- a/agora-specs/Sample/Effect/GovernorMutation.hs
+++ b/agora-specs/Sample/Effect/GovernorMutation.hs
@@ -51,7 +51,7 @@ import Test.Util (datumPair, toDatumHash)
 
 -- | The effect validator instance.
 effectValidator :: Validator
-effectValidator = mkValidator $ mutateGovernorValidator governor
+effectValidator = mkValidator def $ mutateGovernorValidator governor
 
 -- | The hash of the validator instance.
 effectValidatorHash :: ValidatorHash

--- a/agora-specs/Sample/Effect/TreasuryWithdrawal.hs
+++ b/agora-specs/Sample/Effect/TreasuryWithdrawal.hs
@@ -23,6 +23,7 @@ import Agora.Effect.TreasuryWithdrawal (
   TreasuryWithdrawalDatum (TreasuryWithdrawalDatum),
   treasuryWithdrawalValidator,
  )
+import Data.Default (def)
 import Plutarch.Api.V1 (mkValidator, validatorHash)
 import PlutusLedgerApi.V1 (
   Address (Address),
@@ -147,7 +148,7 @@ buildReceiversOutputFromDatum (TreasuryWithdrawalDatum xs _) = f <$> xs
 
 -- | Effect validator instance.
 validator :: Validator
-validator = mkValidator $ treasuryWithdrawalValidator currSymbol
+validator = mkValidator def $ treasuryWithdrawalValidator currSymbol
 
 -- | 'TokenName' that represents the hash of the 'Agora.Stake.Stake' validator.
 validatorHashTN :: TokenName

--- a/agora-specs/Sample/Effect/TreasuryWithdrawal.hs
+++ b/agora-specs/Sample/Effect/TreasuryWithdrawal.hs
@@ -28,7 +28,7 @@ import Plutarch.Api.V1 (mkValidator, validatorHash)
 import PlutusLedgerApi.V1 (
   Address (Address),
   Credential (..),
-  CurrencySymbol (CurrencySymbol),
+  CurrencySymbol,
   DatumHash (DatumHash),
   PubKeyHash,
   ScriptContext (..),
@@ -60,7 +60,7 @@ import Test.Util (scriptCredentials, userCredentials)
 
 -- | A sample Currency Symbol.
 currSymbol :: CurrencySymbol
-currSymbol = CurrencySymbol "12312099"
+currSymbol = "9c04a69c7133e26061fe5a15adaf4f79cd51e47ef22a2e3c91a36f04"
 
 -- | A sample 'PubKeyHash'.
 signer :: PubKeyHash

--- a/agora-specs/Sample/Governor/Initialize.hs
+++ b/agora-specs/Sample/Governor/Initialize.hs
@@ -114,7 +114,7 @@ govValidatorHash :: ValidatorHash
 govValidatorHash = governorValidatorHash governor
 
 govPolicy :: MintingPolicy
-govPolicy = mkMintingPolicy (governorPolicy governor)
+govPolicy = mkMintingPolicy def (governorPolicy governor)
 
 govSymbol :: CurrencySymbol
 govSymbol = mintingPolicySymbol govPolicy
@@ -169,12 +169,16 @@ mintGST ps = builder
         then
           mconcat
             [ input $
-                pubKey witnessPubKey
-                  . withValue witnessValue
-                  . withOutRef witnessRef
+                mconcat
+                  [ pubKey witnessPubKey
+                  , withValue witnessValue
+                  , withOutRef witnessRef
+                  ]
             , output $
-                pubKey witnessPubKey
-                  . withValue witnessValue
+                mconcat
+                  [ pubKey witnessPubKey
+                  , withValue witnessValue
+                  ]
             ]
         else mempty
 
@@ -184,11 +188,13 @@ mintGST ps = builder
       let datum =
             if ps.withGovernorDatum
               then withDatum governorOutputDatum
-              else id
+              else mempty
        in output $
-            script govValidatorHash
-              . withValue governorValue
-              . datum
+            mconcat
+              [ script govValidatorHash
+              , withValue governorValue
+              , datum
+              ]
     --
     builder =
       mconcat

--- a/agora-specs/Sample/Governor/Initialize.hs
+++ b/agora-specs/Sample/Governor/Initialize.hs
@@ -19,16 +19,20 @@ module Sample.Governor.Initialize (
   mkTestCase,
 ) where
 
+import Agora.Bootstrap (agoraScripts)
 import Agora.Governor (Governor (..), GovernorDatum (..))
-import Agora.Governor.Scripts (
-  governorPolicy,
-  governorSTAssetClassFromGovernor,
+import Agora.Proposal (ProposalId (..), ProposalThresholds (..))
+import Agora.Proposal.Time (
+  MaxTimeRangeWidth (MaxTimeRangeWidth),
+  ProposalTimingConfig (ProposalTimingConfig),
+ )
+import Agora.Scripts (
+  AgoraScripts (compiledGovernorPolicy),
+  governorSTAssetClass,
+  governorSTSymbol,
   governorValidatorHash,
  )
-import Agora.Proposal (ProposalId (..), ProposalThresholds (..))
-import Agora.Proposal.Time (MaxTimeRangeWidth (MaxTimeRangeWidth), ProposalTimingConfig (ProposalTimingConfig))
 import Data.Default (Default (..))
-import Plutarch.Api.V1 (mintingPolicySymbol, mkMintingPolicy)
 import Plutarch.Context (
   input,
   mint,
@@ -43,7 +47,6 @@ import Plutarch.Context (
  )
 import PlutusLedgerApi.V1 (
   CurrencySymbol,
-  MintingPolicy,
   TxOutRef (TxOutRef),
   ValidatorHash,
  )
@@ -107,17 +110,17 @@ governor =
     { gstOutRef = witnessRef
     }
 
+scripts :: AgoraScripts
+scripts = agoraScripts Shared.deterministicTracingConfing governor
+
 govAssetClass :: AssetClass
-govAssetClass = governorSTAssetClassFromGovernor governor
+govAssetClass = governorSTAssetClass scripts
 
 govValidatorHash :: ValidatorHash
-govValidatorHash = governorValidatorHash governor
-
-govPolicy :: MintingPolicy
-govPolicy = mkMintingPolicy def (governorPolicy governor)
+govValidatorHash = governorValidatorHash scripts
 
 govSymbol :: CurrencySymbol
-govSymbol = mintingPolicySymbol govPolicy
+govSymbol = governorSTSymbol scripts
 
 --------------------------------------------------------------------------------
 
@@ -271,6 +274,6 @@ mkTestCase name ps valid =
   testPolicy
     valid
     name
-    (governorPolicy governor)
+    scripts.compiledGovernorPolicy
     ()
     (mkMinting mintGST ps govSymbol)

--- a/agora-specs/Sample/Governor/Mutate.hs
+++ b/agora-specs/Sample/Governor/Mutate.hs
@@ -49,7 +49,7 @@ import Sample.Shared (
   minAda,
  )
 import Test.Specification (SpecificationTree, testValidator)
-import Test.Util (CombinableBuilder, mkSpending, pubKeyHashes, sortValue, validatorHashes, withOptional)
+import Test.Util (CombinableBuilder, mkSpending, pubKeyHashes, sortValue, validatorHashes)
 
 --------------------------------------------------------------------------------
 
@@ -142,18 +142,22 @@ mkGovernorBuilder ps =
           then pubKey $ head pubKeyHashes
           else script govValidatorHash
       withGSTDatum =
-        withOptional withDatum $
+        maybe mempty withDatum $
           mkGovernorOutputDatum ps.governorOutputDatumValidity
    in mconcat
         [ input $
-            script govValidatorHash
-              . withDatum governorInputDatum
-              . withValue value
-              . withOutRef governorRef
+            mconcat
+              [ script govValidatorHash
+              , withDatum governorInputDatum
+              , withValue value
+              , withOutRef governorRef
+              ]
         , output $
-            gstOutput
-              . withGSTDatum
-              . withValue value
+            mconcat
+              [ gstOutput
+              , withGSTDatum
+              , withValue value
+              ]
         ]
 
 --------------------------------------------------------------------------------
@@ -162,7 +166,7 @@ mockEffectValidator :: ClosedTerm PValidator
 mockEffectValidator = noOpValidator authorityTokenSymbol
 
 mockEffectValidatorHash :: ValidatorHash
-mockEffectValidatorHash = validatorHash $ mkValidator mockEffectValidator
+mockEffectValidatorHash = validatorHash $ mkValidator def mockEffectValidator
 
 mkGATValue :: GATValidity -> Integer -> Value
 mkGATValue NoGAT _ = mempty
@@ -187,11 +191,15 @@ mkMockEffectBuilder ps =
    in mconcat
         [ mint burnt
         , input $
-            script mockEffectValidatorHash
-              . withValue inputValue
+            mconcat
+              [ script mockEffectValidatorHash
+              , withValue inputValue
+              ]
         , output $
-            script mockEffectValidatorHash
-              . withValue outputValue
+            mconcat
+              [ script mockEffectValidatorHash
+              , withValue outputValue
+              ]
         ]
 
 --------------------------------------------------------------------------------

--- a/agora-specs/Sample/Governor/Mutate.hs
+++ b/agora-specs/Sample/Governor/Mutate.hs
@@ -18,8 +18,8 @@ module Sample.Governor.Mutate (
 
 import Agora.Effect.NoOp (noOpValidator)
 import Agora.Governor (GovernorDatum (..), GovernorRedeemer (MutateGovernor))
-import Agora.Governor.Scripts (governorValidator)
 import Agora.Proposal (ProposalId (ProposalId), ProposalThresholds (..))
+import Agora.Scripts (AgoraScripts (..))
 import Agora.Utils (validatorHashToTokenName)
 import Data.Default (def)
 import Plutarch.Api.V1 (PValidator, mkValidator, validatorHash)
@@ -42,10 +42,10 @@ import PlutusLedgerApi.V1 (
  )
 import PlutusLedgerApi.V1.Value qualified as Value
 import Sample.Shared (
+  agoraScripts,
   authorityTokenSymbol,
   govAssetClass,
   govValidatorHash,
-  governor,
   minAda,
  )
 import Test.Specification (SpecificationTree, testValidator)
@@ -219,7 +219,7 @@ mkTestCase name pb (Validity forGov) =
   testValidator
     forGov
     name
-    (governorValidator governor)
+    agoraScripts.compiledGovernorValidator
     governorInputDatum
     governorRedeemer
     (mkSpending mutate pb governorRef)

--- a/agora-specs/Sample/Proposal/Advance.hs
+++ b/agora-specs/Sample/Proposal/Advance.hs
@@ -321,14 +321,18 @@ mkProposalBuilder ps =
       value = sortValue $ minAda <> pst
    in mconcat
         [ input $
-            script proposalValidatorHash
-              . withOutRef proposalRef
-              . withDatum (mkProposalInputDatum ps)
-              . withValue value
+            mconcat
+              [ script proposalValidatorHash
+              , withOutRef proposalRef
+              , withDatum (mkProposalInputDatum ps)
+              , withValue value
+              ]
         , output $
-            script proposalValidatorHash
-              . withDatum (mkProposalOutputDatum ps)
-              . withValue value
+            mconcat
+              [ script proposalValidatorHash
+              , withDatum (mkProposalOutputDatum ps)
+              , withValue value
+              ]
         ]
 
 {- | The proposal redeemer used to spend the proposal UTXO, which is always
@@ -400,14 +404,18 @@ mkStakeBuilder ps =
          in mconcat
               [ withSig
               , input $
-                  script stakeValidatorHash
-                    . withOutRef (mkStakeRef idx)
-                    . withValue perStakeValue
-                    . withDatum i
+                  mconcat
+                    [ script stakeValidatorHash
+                    , withOutRef (mkStakeRef idx)
+                    , withValue perStakeValue
+                    , withDatum i
+                    ]
               , output $
-                  script stakeValidatorHash
-                    . withValue perStakeValue
-                    . withDatum o
+                  mconcat
+                    [ script stakeValidatorHash
+                    , withValue perStakeValue
+                    , withDatum o
+                    ]
               ]
    in mconcat $
         zipWith3
@@ -457,15 +465,19 @@ mkGovernorBuilder ps =
       value = sortValue $ gst <> minAda
    in mconcat
         [ input $
-            script govValidatorHash
-              . withValue value
-              . withOutRef governorRef
-              . withDatum governorInputDatum
+            mconcat
+              [ script govValidatorHash
+              , withValue value
+              , withOutRef governorRef
+              , withDatum governorInputDatum
+              ]
         , output $
-            script govValidatorHash
-              . withValue value
-              . withOutRef governorRef
-              . withDatum (mkGovernorOutputDatum ps)
+            mconcat
+              [ script govValidatorHash
+              , withValue value
+              , withOutRef governorRef
+              , withDatum (mkGovernorOutputDatum ps)
+              ]
         ]
 
 {- | The proposal redeemer used to spend the governor UTXO, which is always
@@ -501,9 +513,11 @@ mkAuthorityTokenBuilder (AuthorityTokenParameters es mdt invalidTokenName) =
        in mconcat
             [ mint minted
             , output $
-                script vh
-                  . maybe id withDatum mdt
-                  . withValue value
+                mconcat
+                  [ script vh
+                  , maybe mempty withDatum mdt
+                  , withValue value
+                  ]
             ]
 
 -- | The redeemer used while running the authority token policy.

--- a/agora-specs/Sample/Proposal/Cosign.hs
+++ b/agora-specs/Sample/Proposal/Cosign.hs
@@ -162,15 +162,19 @@ cosign ps = builder
                     else stakeDatum
              in mconcat
                   [ input $
-                      script stakeValidatorHash
-                        . withValue stakeValue
-                        . withDatum stakeDatum
-                        . withTxId stakeTxRef
-                        . withOutRef (mkStakeRef refIdx)
+                      mconcat
+                        [ script stakeValidatorHash
+                        , withValue stakeValue
+                        , withDatum stakeDatum
+                        , withTxId stakeTxRef
+                        , withOutRef (mkStakeRef refIdx)
+                        ]
                   , output $
-                      script stakeValidatorHash
-                        . withValue stakeValue
-                        . withDatum stakeOutputDatum
+                      mconcat
+                        [ script stakeValidatorHash
+                        , withValue stakeValue
+                        , withDatum stakeOutputDatum
+                        ]
                   , signedWith stakeDatum.owner
                   ]
         )
@@ -189,15 +193,19 @@ cosign ps = builder
     proposalBuilder =
       mconcat
         [ input $
-            script proposalValidatorHash
-              . withValue pst
-              . withDatum proposalInputDatum
-              . withTxId proposalTxRef
-              . withOutRef proposalRef
+            mconcat
+              [ script proposalValidatorHash
+              , withValue pst
+              , withDatum proposalInputDatum
+              , withTxId proposalTxRef
+              , withOutRef proposalRef
+              ]
         , output $
-            script proposalValidatorHash
-              . withValue (sortValue (pst <> minAda))
-              . withDatum proposalOutputDatum
+            mconcat
+              [ script proposalValidatorHash
+              , withValue (sortValue (pst <> minAda))
+              , withDatum proposalOutputDatum
+              ]
         ]
 
     validTimeRange :: POSIXTimeRange

--- a/agora-specs/Sample/Proposal/Create.hs
+++ b/agora-specs/Sample/Proposal/Create.hs
@@ -302,29 +302,39 @@ createProposal ps = builder
         , ---
           timeRange $ mkTimeRange ps
         , input $
-            script govValidatorHash
-              . withValue governorValue
-              . withDatum governorInputDatum
-              . withOutRef governorRef
+            mconcat
+              [ script govValidatorHash
+              , withValue governorValue
+              , withDatum governorInputDatum
+              , withOutRef governorRef
+              ]
         , output $
-            script govValidatorHash
-              . withValue governorValue
-              . withDatum (mkGovernorOutputDatum ps)
+            mconcat
+              [ script govValidatorHash
+              , withValue governorValue
+              , withDatum (mkGovernorOutputDatum ps)
+              ]
         , ---
           input $
-            script stakeValidatorHash
-              . withValue stakeValue
-              . withDatum (mkStakeInputDatum ps)
-              . withOutRef stakeRef
+            mconcat
+              [ script stakeValidatorHash
+              , withValue stakeValue
+              , withDatum (mkStakeInputDatum ps)
+              , withOutRef stakeRef
+              ]
         , output $
-            script stakeValidatorHash
-              . withValue stakeValue
-              . withDatum (mkStakeOutputDatum ps)
+            mconcat
+              [ script stakeValidatorHash
+              , withValue stakeValue
+              , withDatum (mkStakeOutputDatum ps)
+              ]
         , ---
           output $
-            script proposalValidatorHash
-              . withValue proposalValue
-              . withDatum (mkProposalOutputDatum ps)
+            mconcat
+              [ script proposalValidatorHash
+              , withValue proposalValue
+              , withDatum (mkProposalOutputDatum ps)
+              ]
         ]
 
 --------------------------------------------------------------------------------

--- a/agora-specs/Sample/Proposal/Create.hs
+++ b/agora-specs/Sample/Proposal/Create.hs
@@ -20,27 +20,24 @@ module Sample.Proposal.Create (
 ) where
 
 import Agora.Governor (
+  Governor (..),
   GovernorDatum (..),
   GovernorRedeemer (CreateProposal),
  )
-import Agora.Governor.Scripts (governorValidator)
 import Agora.Proposal (
-  Proposal (governorSTAssetClass),
   ProposalDatum (..),
   ProposalId (ProposalId),
   ProposalStatus (..),
   ResultTag (ResultTag),
   emptyVotesFor,
  )
-import Agora.Proposal.Scripts (proposalPolicy)
 import Agora.Proposal.Time (MaxTimeRangeWidth (MaxTimeRangeWidth), ProposalStartingTime (..))
+import Agora.Scripts (AgoraScripts (..))
 import Agora.Stake (
   ProposalLock (..),
-  Stake (gtClassRef),
   StakeDatum (..),
   StakeRedeemer (PermitVote),
  )
-import Agora.Stake.Scripts (stakeValidator)
 import Data.Coerce (coerce)
 import Data.Default (Default (def))
 import Data.Tagged (Tagged, untag)
@@ -69,19 +66,19 @@ import PlutusLedgerApi.V1.Value qualified as Value
 import PlutusTx.AssocMap qualified as AssocMap
 import Sample.Proposal.Shared (stakeTxRef)
 import Sample.Shared (
+  agoraScripts,
+  govAssetClass,
   govValidatorHash,
+  governor,
   minAda,
-  proposal,
   proposalPolicySymbol,
   proposalStartingTimeFromTimeRange,
   proposalValidatorHash,
   signer,
   signer2,
-  stake,
   stakeAssetClass,
   stakeValidatorHash,
  )
-import Sample.Shared qualified as Shared
 import Test.Specification (SpecificationTree, group, testPolicy, testValidator)
 import Test.Util (CombinableBuilder, closedBoundedInterval, mkMinting, mkSpending, sortValue)
 
@@ -270,7 +267,7 @@ createProposal ps = builder
   where
     pst = Value.singleton proposalPolicySymbol "" 1
     sst = Value.assetClassValue stakeAssetClass 1
-    gst = Value.assetClassValue proposal.governorSTAssetClass 1
+    gst = Value.assetClassValue govAssetClass 1
 
     ---
 
@@ -279,7 +276,7 @@ createProposal ps = builder
       sortValue $
         sortValue $
           sst
-            <> Value.assetClassValue (untag stake.gtClassRef) (untag stakedGTs)
+            <> Value.assetClassValue (untag governor.gtClassRef) (untag stakedGTs)
             <> minAda
     proposalValue = sortValue $ pst <> minAda
 
@@ -438,7 +435,7 @@ mkTestTree
         testPolicy
           validForProposalPolicy
           "proposal"
-          (proposalPolicy Shared.proposal.governorSTAssetClass)
+          agoraScripts.compiledProposalPolicy
           proposalPolicyRedeemer
           (mint proposalPolicySymbol)
 
@@ -446,15 +443,16 @@ mkTestTree
         testValidator
           validForGovernorValidator
           "governor"
-          (governorValidator Shared.governor)
+          agoraScripts.compiledGovernorValidator
           governorInputDatum
           governorRedeemer
           (spend governorRef)
+
       stakeTest =
         testValidator
           validForStakeValidator
           "stake"
-          (stakeValidator Shared.stake)
+          agoraScripts.compiledStakeValidator
           (mkStakeInputDatum ps)
           stakeRedeemer
           (spend stakeRef)

--- a/agora-specs/Sample/Proposal/UnlockStake.hs
+++ b/agora-specs/Sample/Proposal/UnlockStake.hs
@@ -257,14 +257,18 @@ unlockStake ps =
           ( \((i, o), idx) ->
               mconcat
                 [ input $
-                    script proposalValidatorHash
-                      . withValue pst
-                      . withDatum i
-                      . withOutRef (mkProposalRef idx)
+                    mconcat
+                      [ script proposalValidatorHash
+                      , withValue pst
+                      , withDatum i
+                      , withOutRef (mkProposalRef idx)
+                      ]
                 , output $
-                    script proposalValidatorHash
-                      . withValue (sortValue $ pst <> minAda)
-                      . withDatum o
+                    mconcat
+                      [ script proposalValidatorHash
+                      , withValue (sortValue $ pst <> minAda)
+                      , withDatum o
+                      ]
                 ]
           )
           (zip pIODatums [0 ..])
@@ -285,14 +289,18 @@ unlockStake ps =
       stakes =
         mconcat
           [ input $
-              script stakeValidatorHash
-                . withValue stakeValue
-                . withDatum sInDatum
-                . withOutRef stakeRef
+              mconcat
+                [ script stakeValidatorHash
+                , withValue stakeValue
+                , withDatum sInDatum
+                , withOutRef stakeRef
+                ]
           , output $
-              script stakeValidatorHash
-                . withValue stakeValue
-                . withDatum sOutDatum
+              mconcat
+                [ script stakeValidatorHash
+                , withValue stakeValue
+                , withDatum sOutDatum
+                ]
           ]
 
       builder =

--- a/agora-specs/Sample/Proposal/Vote.hs
+++ b/agora-specs/Sample/Proposal/Vote.hs
@@ -219,23 +219,31 @@ vote params =
           , signedWith signer
           , timeRange validTimeRange
           , input $
-              script proposalValidatorHash
-                . withValue pst
-                . withDatum proposalInputDatum
-                . withOutRef proposalRef
+              mconcat
+                [ script proposalValidatorHash
+                , withValue pst
+                , withDatum proposalInputDatum
+                , withOutRef proposalRef
+                ]
           , input $
-              script stakeValidatorHash
-                . withValue stakeValue
-                . withDatum stakeInputDatum
-                . withOutRef stakeRef
+              mconcat
+                [ script stakeValidatorHash
+                , withValue stakeValue
+                , withDatum stakeInputDatum
+                , withOutRef stakeRef
+                ]
           , output $
-              script proposalValidatorHash
-                . withValue pst
-                . withDatum proposalOutputDatum
+              mconcat
+                [ script proposalValidatorHash
+                , withValue pst
+                , withDatum proposalOutputDatum
+                ]
           , output $
-              script stakeValidatorHash
-                . withValue stakeValue
-                . withDatum stakeOutputDatum
+              mconcat
+                [ script stakeValidatorHash
+                , withValue stakeValue
+                , withDatum stakeOutputDatum
+                ]
           ]
    in builder
 

--- a/agora-specs/Sample/Proposal/Vote.hs
+++ b/agora-specs/Sample/Proposal/Vote.hs
@@ -11,6 +11,7 @@ module Sample.Proposal.Vote (
   validVoteAsDelegateParameters,
 ) where
 
+import Agora.Governor (Governor (..))
 import Agora.Proposal (
   ProposalDatum (..),
   ProposalId (ProposalId),
@@ -19,18 +20,16 @@ import Agora.Proposal (
   ProposalVotes (ProposalVotes),
   ResultTag (ResultTag),
  )
-import Agora.Proposal.Scripts (proposalValidator)
 import Agora.Proposal.Time (
   ProposalStartingTime (ProposalStartingTime),
   ProposalTimingConfig (draftTime, votingTime),
  )
+import Agora.Scripts (AgoraScripts (..))
 import Agora.Stake (
   ProposalLock (..),
-  Stake (gtClassRef),
   StakeDatum (..),
   StakeRedeemer (PermitVote),
  )
-import Agora.Stake.Scripts (stakeValidator)
 import Data.Default (Default (def))
 import Data.Tagged (Tagged (Tagged), untag)
 import Plutarch.Context (
@@ -52,15 +51,15 @@ import PlutusLedgerApi.V1.Value qualified as Value
 import PlutusTx.AssocMap qualified as AssocMap
 import Sample.Proposal.Shared (proposalTxRef, stakeTxRef)
 import Sample.Shared (
+  agoraScripts,
+  governor,
   minAda,
   proposalPolicySymbol,
   proposalValidatorHash,
   signer,
-  stake,
   stakeAssetClass,
   stakeValidatorHash,
  )
-import Sample.Shared qualified as Shared
 import Test.Specification (
   SpecificationTree,
   group,
@@ -205,7 +204,7 @@ vote params =
       stakeValue =
         sortValue $
           sst
-            <> Value.assetClassValue (untag stake.gtClassRef) params.voteCount
+            <> Value.assetClassValue (untag governor.gtClassRef) params.voteCount
             <> minAda
 
       signer =
@@ -278,7 +277,7 @@ mkTestTree name ps isValid = group name [proposal, stake]
       testValidator
         isValid
         "proposal"
-        (proposalValidator Shared.proposal)
+        agoraScripts.compiledProposalValidator
         proposalInputDatum
         (mkProposalRedeemer ps)
         (spend proposalRef)
@@ -287,7 +286,7 @@ mkTestTree name ps isValid = group name [proposal, stake]
       let stakeInputDatum = mkStakeInputDatum ps
        in validatorSucceedsWith
             "stake"
-            (stakeValidator Shared.stake)
+            agoraScripts.compiledStakeValidator
             stakeInputDatum
             stakeRedeemer
             (spend stakeRef)

--- a/agora-specs/Sample/Shared.hs
+++ b/agora-specs/Sample/Shared.hs
@@ -141,10 +141,10 @@ governor = Governor oref gt mc
     mc = 20
 
 govPolicy :: MintingPolicy
-govPolicy = mkMintingPolicy (governorPolicy governor)
+govPolicy = mkMintingPolicy def (governorPolicy governor)
 
 govValidator :: Validator
-govValidator = mkValidator (governorValidator governor)
+govValidator = mkValidator def (governorValidator governor)
 
 govSymbol :: CurrencySymbol
 govSymbol = mintingPolicySymbol govPolicy
@@ -239,7 +239,7 @@ gatCs :: CurrencySymbol
 gatCs = "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
 
 trValidator :: Validator
-trValidator = mkValidator (treasuryValidator gatCs)
+trValidator = mkValidator def (treasuryValidator gatCs)
 
 -- | `ScriptCredential` used for the dummy treasury validator.
 trCredential :: Credential
@@ -251,7 +251,7 @@ gatTn = validatorHashToTokenName $ validatorHash mockTrEffect
 
 -- | Mock treasury effect script, used for testing.
 mockTrEffect :: Validator
-mockTrEffect = mkValidator $ noOpValidator gatCs
+mockTrEffect = mkValidator def $ noOpValidator gatCs
 
 -- | Mock treasury effect validator hash
 mockTrEffectHash :: ValidatorHash

--- a/agora-specs/Sample/Stake.hs
+++ b/agora-specs/Sample/Stake.hs
@@ -6,10 +6,8 @@ Description: Sample based testing for Stake utxos
 This module tests primarily the happy path for Stake creation
 -}
 module Sample.Stake (
-  stake,
   stakeAssetClass,
   stakeSymbol,
-  validatorHashTN,
   signer,
 
   -- * Script contexts
@@ -20,15 +18,12 @@ module Sample.Stake (
   DepositWithdrawExample (..),
 ) where
 
+import Agora.Governor (Governor (gtClassRef))
 import Agora.SafeMoney (GTTag)
 import Agora.Stake (
-  Stake (gtClassRef),
   StakeDatum (StakeDatum, stakedAmount),
  )
-import Agora.Stake.Scripts (stakeValidator)
-import Data.Default (def)
 import Data.Tagged (Tagged, untag)
-import Plutarch.Api.V1 (mkValidator, validatorHash)
 import Plutarch.Context (
   MintingBuilder,
   SpendingBuilder,
@@ -51,9 +46,7 @@ import PlutusLedgerApi.V1 (
   ScriptContext (..),
   ScriptPurpose (Minting),
   ToData (toBuiltinData),
-  TokenName (TokenName),
   TxInfo (txInfoData, txInfoSignatories),
-  ValidatorHash (ValidatorHash),
  )
 import PlutusLedgerApi.V1.Contexts (TxOutRef (..))
 import PlutusLedgerApi.V1.Value qualified as Value (
@@ -61,19 +54,13 @@ import PlutusLedgerApi.V1.Value qualified as Value (
   singleton,
  )
 import Sample.Shared (
+  governor,
   signer,
-  stake,
   stakeAssetClass,
   stakeSymbol,
   stakeValidatorHash,
  )
-
--- | 'TokenName' that represents the hash of the 'Stake' validator.
-validatorHashTN :: TokenName
-validatorHashTN =
-  let validator = mkValidator def $ stakeValidator stake
-      ValidatorHash vh = validatorHash validator
-   in TokenName vh
+import Test.Util (sortValue)
 
 -- | This script context should be a valid transaction.
 stakeCreation :: ScriptContext
@@ -151,14 +138,22 @@ stakeDepositWithdraw config =
           , input $
               mconcat
                 [ script stakeValidatorHash
-                , withValue (st <> Value.assetClassValue (untag stake.gtClassRef) (untag stakeBefore.stakedAmount))
+                , withValue
+                    ( sortValue $
+                        st
+                          <> Value.assetClassValue (untag governor.gtClassRef) (untag stakeBefore.stakedAmount)
+                    )
                 , withDatum stakeAfter
                 , withOutRef stakeRef
                 ]
           , output $
               mconcat
                 [ script stakeValidatorHash
-                , withValue (st <> Value.assetClassValue (untag stake.gtClassRef) (untag stakeAfter.stakedAmount))
+                , withValue
+                    ( sortValue $
+                        st
+                          <> Value.assetClassValue (untag governor.gtClassRef) (untag stakeAfter.stakedAmount)
+                    )
                 , withDatum stakeAfter
                 ]
           , withSpendingOutRef stakeRef

--- a/agora-specs/Sample/Stake/SetDelegate.hs
+++ b/agora-specs/Sample/Stake/SetDelegate.hs
@@ -129,14 +129,18 @@ setDelegate ps = buildSpendingUnsafe builder
         [ txId "0b2086cbf8b6900f8cb65e012de4516cb66b5cb08a9aaba12a8b88be"
         , signedWith signer
         , input $
-            script stakeValidatorHash
-              . withValue stakeValue
-              . withDatum stakeInput
-              . withOutRef stakeRef
+            mconcat
+              [ script stakeValidatorHash
+              , withValue stakeValue
+              , withDatum stakeInput
+              , withOutRef stakeRef
+              ]
         , output $
-            script stakeValidatorHash
-              . withValue stakeValue
-              . withDatum stakeOutput
+            mconcat
+              [ script stakeValidatorHash
+              , withValue stakeValue
+              , withDatum stakeOutput
+              ]
         , withSpendingOutRef stakeRef
         ]
 

--- a/agora-specs/Sample/Stake/SetDelegate.hs
+++ b/agora-specs/Sample/Stake/SetDelegate.hs
@@ -19,12 +19,12 @@ module Sample.Stake.SetDelegate (
   delegateToOwnerParameters,
 ) where
 
+import Agora.Governor (Governor (gtClassRef))
+import Agora.Scripts (AgoraScripts (..))
 import Agora.Stake (
-  Stake (gtClassRef),
   StakeDatum (..),
   StakeRedeemer (ClearDelegate, DelegateTo),
  )
-import Agora.Stake.Scripts (stakeValidator)
 import Data.Tagged (untag)
 import Plutarch.Context (
   SpendingBuilder,
@@ -46,10 +46,11 @@ import PlutusLedgerApi.V1 (
  )
 import PlutusLedgerApi.V1.Value qualified as Value
 import Sample.Shared (
+  agoraScripts,
+  governor,
   minAda,
   signer,
   signer2,
-  stake,
   stakeAssetClass,
   stakeValidatorHash,
  )
@@ -118,7 +119,7 @@ setDelegate ps = buildSpendingUnsafe builder
         mconcat
           [ st
           , Value.assetClassValue
-              (untag stake.gtClassRef)
+              (untag governor.gtClassRef)
               (untag stakeInput.stakedAmount)
           , minAda
           ]
@@ -154,7 +155,7 @@ mkTestCase name ps valid =
   testValidator
     valid
     name
-    (stakeValidator stake)
+    agoraScripts.compiledStakeValidator
     (mkStakeInputDatum ps)
     (mkStakeRedeemer ps)
     (setDelegate ps)

--- a/agora-specs/Sample/Treasury.hs
+++ b/agora-specs/Sample/Treasury.hs
@@ -19,7 +19,6 @@ module Sample.Treasury (
 
 import Plutarch.Context (
   MintingBuilder,
-  UTXO,
   buildMintingUnsafe,
   credential,
   input,
@@ -57,11 +56,12 @@ import Sample.Shared (
 
 baseCtxBuilder :: MintingBuilder
 baseCtxBuilder =
-  let treasury :: UTXO -> UTXO
-      treasury =
-        credential trCredential
-          . withValue minAda
-          . withTxId "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
+  let treasury =
+        mconcat
+          [ credential trCredential
+          , withValue minAda
+          , withTxId "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
+          ]
    in mconcat
         [ txId "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
         , signedWith signer
@@ -81,9 +81,11 @@ validCtx =
         mconcat
           [ baseCtxBuilder
           , input $
-              script mockTrEffectHash
-                . withValue (Value.singleton gatCs gatTn 1 <> minAda)
-                . withTxId "52b67b60260da3937510ad545c7f46f8d9915bd27e1082e76947fb309f913bd3"
+              mconcat
+                [ script mockTrEffectHash
+                , withValue (Value.singleton gatCs gatTn 1 <> minAda)
+                , withTxId "52b67b60260da3937510ad545c7f46f8d9915bd27e1082e76947fb309f913bd3"
+                ]
           ]
    in buildMintingUnsafe builder
 
@@ -122,8 +124,10 @@ trCtxGATNameNotAddress =
         mconcat
           [ baseCtxBuilder
           , input $
-              script wrongEffHash
-                . withValue (Value.singleton gatCs gatTn 1 <> minAda)
-                . withTxId "52b67b60260da3937510ad545c7f46f8d9915bd27e1082e76947fb309f913bd3"
+              mconcat
+                [ script wrongEffHash
+                , withValue (Value.singleton gatCs gatTn 1 <> minAda)
+                , withTxId "52b67b60260da3937510ad545c7f46f8d9915bd27e1082e76947fb309f913bd3"
+                ]
           ]
    in buildMintingUnsafe builder

--- a/agora-specs/Spec/AuthorityToken.hs
+++ b/agora-specs/Spec/AuthorityToken.hs
@@ -10,7 +10,8 @@ Tests for Authority token functions
 module Spec.AuthorityToken (specs) where
 
 import Agora.AuthorityToken (singleAuthorityTokenBurned)
-import Plutarch (ClosedTerm, POpaque, compile, perror, popaque)
+import Plutarch (ClosedTerm, POpaque, perror, popaque)
+import Plutarch.Extra.Compile (mustCompile)
 import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V1 (
   Address (Address),
@@ -60,7 +61,7 @@ singleAuthorityTokenBurnedTest mint outs =
           actual
           (popaque (pconstant ()))
           perror
-   in compile s
+   in mustCompile s
 
 -- | The SpecificationTree exported by this module.
 specs :: [SpecificationTree]

--- a/agora-specs/Spec/Effect/GovernorMutation.hs
+++ b/agora-specs/Spec/Effect/GovernorMutation.hs
@@ -2,8 +2,8 @@ module Spec.Effect.GovernorMutation (specs) where
 
 import Agora.Effect.GovernorMutation (mutateGovernorValidator)
 import Agora.Governor (GovernorDatum (..), GovernorRedeemer (MutateGovernor))
-import Agora.Governor.Scripts (governorValidator)
 import Agora.Proposal (ProposalId (..))
+import Agora.Scripts (AgoraScripts (..))
 import Data.Default.Class (Default (def))
 import PlutusLedgerApi.V1 (ScriptContext (ScriptContext), ScriptPurpose (Spending))
 import Sample.Effect.GovernorMutation (
@@ -14,7 +14,7 @@ import Sample.Effect.GovernorMutation (
   mkEffectTxInfo,
   validNewGovernorDatum,
  )
-import Sample.Shared qualified as Shared
+import Sample.Shared (agoraScripts, mkEffect)
 import Test.Specification (
   SpecificationTree,
   effectFailsWith,
@@ -32,7 +32,7 @@ specs =
           "valid new governor datum"
           [ validatorSucceedsWith
               "governor validator should pass"
-              (governorValidator Shared.governor)
+              agoraScripts.compiledGovernorValidator
               ( GovernorDatum
                   def
                   (ProposalId 0)
@@ -47,7 +47,7 @@ specs =
               )
           , effectSucceedsWith
               "effect validator should pass"
-              (mutateGovernorValidator Shared.governor)
+              (mkEffect $ mutateGovernorValidator agoraScripts)
               (mkEffectDatum validNewGovernorDatum)
               (ScriptContext (mkEffectTxInfo validNewGovernorDatum) (Spending effectRef))
           ]
@@ -55,7 +55,7 @@ specs =
           "invalid new governor datum"
           [ validatorFailsWith
               "governor validator should fail"
-              (governorValidator Shared.governor)
+              agoraScripts.compiledGovernorValidator
               ( GovernorDatum
                   def
                   (ProposalId 0)
@@ -70,7 +70,7 @@ specs =
               )
           , effectFailsWith
               "effect validator should fail"
-              (mutateGovernorValidator Shared.governor)
+              (mkEffect $ mutateGovernorValidator agoraScripts)
               (mkEffectDatum validNewGovernorDatum)
               (ScriptContext (mkEffectTxInfo invalidNewGovernorDatum) (Spending effectRef))
           ]

--- a/agora-specs/Spec/Effect/TreasuryWithdrawal.hs
+++ b/agora-specs/Spec/Effect/TreasuryWithdrawal.hs
@@ -25,12 +25,14 @@ import Sample.Effect.TreasuryWithdrawal (
   treasuries,
   users,
  )
+import Sample.Shared (mkEffect)
 import Test.Specification (
   SpecificationTree,
   effectFailsWith,
   effectSucceedsWith,
   group,
  )
+import Test.Util (sortValue)
 
 specs :: [SpecificationTree]
 specs =
@@ -38,7 +40,7 @@ specs =
       "effect"
       [ effectSucceedsWith
           "Simple"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum1
           ( buildScriptContext
               [ inputGAT
@@ -50,7 +52,7 @@ specs =
           )
       , effectSucceedsWith
           "Simple with multiple treasuries "
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum1
           ( buildScriptContext
               [ inputGAT
@@ -67,7 +69,7 @@ specs =
           )
       , effectSucceedsWith
           "Mixed Assets"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum2
           ( buildScriptContext
               [ inputGAT
@@ -82,7 +84,7 @@ specs =
           )
       , effectFailsWith
           "Pay to uknown 3rd party"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum2
           ( buildScriptContext
               [ inputGAT
@@ -98,7 +100,7 @@ specs =
           )
       , effectFailsWith
           "Missing receiver"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum2
           ( buildScriptContext
               [ inputGAT
@@ -113,7 +115,7 @@ specs =
           )
       , effectFailsWith
           "Unauthorized treasury"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum3
           ( buildScriptContext
               [ inputGAT
@@ -125,7 +127,7 @@ specs =
           )
       , effectFailsWith
           "Prevent transactions besides the withdrawal"
-          (treasuryWithdrawalValidator currSymbol)
+          (mkEffect $ treasuryWithdrawalValidator currSymbol)
           datum3
           ( buildScriptContext
               [ inputGAT
@@ -141,8 +143,14 @@ specs =
       ]
   ]
   where
-    asset1 = Value.singleton "abbc12" "OrangeBottle"
-    asset2 = Value.singleton "abbc12" "19721121"
+    asset1 =
+      Value.singleton
+        "0d586e057e76238f8c56c0752507bfa45ae13b04f8497a311d4aaa48"
+        "OrangeBottle"
+    asset2 =
+      Value.singleton
+        "7e6aa764bceeba1f7acf47d20f1a2a85440afa2928f8ae96376f4d85"
+        "19721121"
     datum1 =
       TreasuryWithdrawalDatum
         [ (head users, asset1 1)
@@ -155,8 +163,8 @@ specs =
         ]
     datum2 =
       TreasuryWithdrawalDatum
-        [ (head users, asset2 5 <> asset1 4)
-        , (users !! 1, asset2 1 <> asset1 2)
+        [ (head users, sortValue $ asset2 5 <> asset1 4)
+        , (users !! 1, sortValue $ asset2 1 <> asset1 2)
         , (users !! 2, asset1 1)
         ]
         [ head treasuries

--- a/agora-specs/Spec/Stake.hs
+++ b/agora-specs/Spec/Stake.hs
@@ -9,14 +9,14 @@ Tests for Stake policy and validator
 -}
 module Spec.Stake (specs) where
 
+import Agora.Scripts (AgoraScripts (..))
 import Agora.Stake (
-  Stake (..),
   StakeDatum (StakeDatum),
   StakeRedeemer (DepositWithdraw),
  )
-import Agora.Stake.Scripts (stakePolicy, stakeValidator)
 import Data.Bool (Bool (..))
 import Data.Maybe (Maybe (..))
+import Sample.Shared (agoraScripts)
 import Sample.Stake (
   DepositWithdrawExample (
     DepositWithdrawExample,
@@ -26,7 +26,6 @@ import Sample.Stake (
   signer,
  )
 import Sample.Stake qualified as Stake (
-  stake,
   stakeCreation,
   stakeCreationUnsigned,
   stakeCreationWrongDatum,
@@ -41,7 +40,6 @@ import Test.Specification (
   validatorFailsWith,
   validatorSucceedsWith,
  )
-import Test.Util (toDatum)
 import Prelude (Num (negate), ($))
 
 -- | The SpecificationTree exported by this module.
@@ -51,17 +49,17 @@ specs =
       "policy"
       [ policySucceedsWith
           "stakeCreation"
-          (stakePolicy Stake.stake.gtClassRef)
+          agoraScripts.compiledStakePolicy
           ()
           Stake.stakeCreation
       , policyFailsWith
           "stakeCreationWrongDatum"
-          (stakePolicy Stake.stake.gtClassRef)
+          agoraScripts.compiledStakePolicy
           ()
           Stake.stakeCreationWrongDatum
       , policyFailsWith
           "stakeCreationUnsigned"
-          (stakePolicy Stake.stake.gtClassRef)
+          agoraScripts.compiledStakePolicy
           ()
           Stake.stakeCreationUnsigned
       ]
@@ -69,21 +67,21 @@ specs =
       "validator"
       [ validatorSucceedsWith
           "stakeDepositWithdraw deposit"
-          (stakeValidator Stake.stake)
-          (toDatum $ StakeDatum 100_000 signer Nothing [])
-          (toDatum $ DepositWithdraw 100_000)
+          agoraScripts.compiledStakeValidator
+          (StakeDatum 100_000 signer Nothing [])
+          (DepositWithdraw 100_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = 100_000})
       , validatorSucceedsWith
           "stakeDepositWithdraw withdraw"
-          (stakeValidator Stake.stake)
-          (toDatum $ StakeDatum 100_000 signer Nothing [])
-          (toDatum $ DepositWithdraw $ negate 100_000)
+          agoraScripts.compiledStakeValidator
+          (StakeDatum 100_000 signer Nothing [])
+          (DepositWithdraw $ negate 100_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = negate 100_000})
       , validatorFailsWith
           "stakeDepositWithdraw negative GT"
-          (stakeValidator Stake.stake)
-          (toDatum $ StakeDatum 100_000 signer Nothing [])
-          (toDatum $ DepositWithdraw 1_000_000)
+          agoraScripts.compiledStakeValidator
+          (StakeDatum 100_000 signer Nothing [])
+          (DepositWithdraw 1_000_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = negate 1_000_000})
       , group
           "set delegate"

--- a/agora-testlib/Test/Specification.hs
+++ b/agora-testlib/Test/Specification.hs
@@ -52,6 +52,7 @@ module Test.Specification (
 import Plutarch.Api.V1 (PMintingPolicy, PValidator)
 import Plutarch.Builtin (pforgetData)
 import Plutarch.Evaluate (evalScript)
+import Plutarch.Extra.Compile (mustCompile)
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
 import PlutusLedgerApi.V1 (Script, ScriptContext)
 import PlutusTx.IsData qualified as PlutusTx (ToData)
@@ -164,7 +165,7 @@ policySucceedsWith ::
   SpecificationTree
 policySucceedsWith tag policy redeemer scriptContext =
   scriptSucceeds tag $
-    compile
+    mustCompile
       ( policy
           # pforgetData (pconstantData redeemer)
           # pconstant scriptContext
@@ -182,7 +183,7 @@ policyFailsWith ::
   SpecificationTree
 policyFailsWith tag policy redeemer scriptContext =
   scriptFails tag $
-    compile
+    mustCompile
       ( policy
           # pforgetData (pconstantData redeemer)
           # pconstant scriptContext
@@ -203,7 +204,7 @@ validatorSucceedsWith ::
   SpecificationTree
 validatorSucceedsWith tag validator datum redeemer scriptContext =
   scriptSucceeds tag $
-    compile
+    mustCompile
       ( validator
           # pforgetData (pconstantData datum)
           # pforgetData (pconstantData redeemer)
@@ -225,7 +226,7 @@ validatorFailsWith ::
   SpecificationTree
 validatorFailsWith tag validator datum redeemer scriptContext =
   scriptFails tag $
-    compile
+    mustCompile
       ( validator
           # pforgetData (pconstantData datum)
           # pforgetData (pconstantData redeemer)

--- a/agora-testlib/Test/Util.hs
+++ b/agora-testlib/Test/Util.hs
@@ -19,7 +19,6 @@ module Test.Util (
   scriptCredentials,
   validatorHashes,
   groupsOfN,
-  withOptional,
   mkSpending,
   mkMinting,
   CombinableBuilder,
@@ -37,7 +36,6 @@ import Data.ByteString.Lazy qualified as ByteString.Lazy
 import Data.List (sortOn)
 import Plutarch.Context (
   Builder,
-  UTXO,
   buildMintingUnsafe,
   buildSpendingUnsafe,
   withMinting,
@@ -181,15 +179,6 @@ groupsOfN n xs =
        in (x : xs', rest)
 
 --------------------------------------------------------------------------------
-
--- | Optionally apply a modifier to the given 'UTXO'.
-withOptional ::
-  (a -> UTXO -> UTXO) ->
-  Maybe a ->
-  UTXO ->
-  UTXO
-withOptional f (Just b) = f b
-withOptional _ _ = id
 
 {- | Given the builder generator and the parameters, create a 'ScriptContext'
     that spends the UTXO that referenced by the given 'TxOutRef'.

--- a/agora.cabal
+++ b/agora.cabal
@@ -95,6 +95,7 @@ common deps
     , bytestring
     , cardano-binary
     , cardano-prelude
+    , composition-prelude
     , containers
     , data-default
     , data-default-class
@@ -143,6 +144,7 @@ library
   exposed-modules:
     Agora.Aeson.Orphans
     Agora.AuthorityToken
+    Agora.Bootstrap
     Agora.Effect
     Agora.Effect.GovernorMutation
     Agora.Effect.NoOp
@@ -154,6 +156,7 @@ library
     Agora.Proposal.Scripts
     Agora.Proposal.Time
     Agora.SafeMoney
+    Agora.Scripts
     Agora.Stake
     Agora.Stake.Scripts
     Agora.Treasury

--- a/agora/Agora/AuthorityToken.hs
+++ b/agora/Agora/AuthorityToken.hs
@@ -12,7 +12,6 @@ module Agora.AuthorityToken (
   AuthorityToken (..),
 ) where
 
-import GHC.Generics qualified as GHC
 import Plutarch.Api.V1 (
   AmountGuarantees,
   KeyGuarantees,
@@ -53,7 +52,7 @@ newtype AuthorityToken = AuthorityToken
   }
   deriving stock
     ( -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
 
 --------------------------------------------------------------------------------
@@ -105,7 +104,7 @@ authorityTokensValidIn = phoistAcyclic $
 singleAuthorityTokenBurned ::
   forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
   Term s PCurrencySymbol ->
-  Term s (PBuiltinList (PAsData PTxInInfo)) ->
+  Term s (PBuiltinList PTxInInfo) ->
   Term s (PValue keys amounts) ->
   Term s PBool
 singleAuthorityTokenBurned gatCs inputs mint = unTermCont $ do
@@ -120,7 +119,7 @@ singleAuthorityTokenBurned gatCs inputs mint = unTermCont $ do
           pall
             # plam
               ( \txInInfo' -> unTermCont $ do
-                  PTxInInfo txInInfo <- pmatchC (pfromData txInInfo')
+                  PTxInInfo txInInfo <- pmatchC txInInfo'
                   let txOut' = pfield @"resolved" # txInInfo
                   pure $ authorityTokensValidIn # gatCs # pfromData txOut'
               )
@@ -156,9 +155,7 @@ authorityTokenPolicy params =
               pguardC "All outputs only emit valid GATs" $
                 pall
                   # plam
-                    ( (authorityTokensValidIn # ownSymbol #)
-                        . pfromData
-                    )
+                    (authorityTokensValidIn # ownSymbol #)
                   # txInfo.outputs
               pure $ popaque $ pconstant ()
           )

--- a/agora/Agora/Bootstrap.hs
+++ b/agora/Agora/Bootstrap.hs
@@ -1,0 +1,67 @@
+{- | Module     : Agora.Bootstrap
+     Maintainer : connor@mlabs.city
+     Description: Initialize a governance system
+
+     Initialize a governance system
+-}
+module Agora.Bootstrap (agoraScripts) where
+
+import Agora.AuthorityToken (AuthorityToken (..), authorityTokenPolicy)
+import Agora.Governor (Governor (..))
+import Agora.Governor.Scripts (governorPolicy, governorValidator)
+import Agora.Proposal.Scripts (proposalPolicy, proposalValidator)
+import Agora.Scripts (AgoraScripts (AgoraScripts))
+import Agora.Scripts qualified as Scripts
+import Agora.Stake.Scripts (stakePolicy, stakeValidator)
+import Agora.Treasury (treasuryValidator)
+import Agora.Utils (
+  CompiledMintingPolicy (..),
+  CompiledValidator (..),
+ )
+import Plutarch (Config)
+import Plutarch.Api.V1 (
+  mintingPolicySymbol,
+  mkMintingPolicy,
+  mkValidator,
+ )
+import PlutusLedgerApi.V1.Value (AssetClass (..))
+
+{- | Parameterize and precompiled core scripts, given the
+     'Agora.Governor.Governor' parameters and plutarch configurations.
+
+     @since 0.2.0
+-}
+agoraScripts :: Config -> Governor -> AgoraScripts
+agoraScripts conf gov = scripts
+  where
+    mkMintingPolicy' = mkMintingPolicy conf
+    mkValidator' = mkValidator conf
+
+    compiledGovernorPolicy = mkMintingPolicy' $ governorPolicy gov.gstOutRef
+    compiledGovernorValidator = mkValidator' $ governorValidator scripts
+    governorSymbol = mintingPolicySymbol compiledGovernorPolicy
+    governorAssetClass = AssetClass (governorSymbol, "")
+
+    authority = AuthorityToken governorAssetClass
+    compiledAuthorityPolicy = mkMintingPolicy' $ authorityTokenPolicy authority
+    authorityTokenSymbol = mintingPolicySymbol compiledAuthorityPolicy
+
+    compiledProposalPolicy = mkMintingPolicy' $ proposalPolicy governorAssetClass
+    compiledProposalValidator = mkValidator' $ proposalValidator scripts gov.maximumCosigners
+
+    compiledStakePolicy = mkMintingPolicy' $ stakePolicy gov.gtClassRef
+    compiledStakeValidator = mkValidator' $ stakeValidator scripts gov.gtClassRef
+
+    compiledTreasuryValidator = mkValidator' $ treasuryValidator authorityTokenSymbol
+
+    scripts =
+      AgoraScripts
+        { Scripts.compiledGovernorPolicy = CompiledMintingPolicy compiledGovernorPolicy
+        , Scripts.compiledGovernorValidator = CompiledValidator compiledGovernorValidator
+        , Scripts.compiledStakePolicy = CompiledMintingPolicy compiledStakePolicy
+        , Scripts.compiledStakeValidator = CompiledValidator compiledStakeValidator
+        , Scripts.compiledProposalPolicy = CompiledMintingPolicy compiledProposalPolicy
+        , Scripts.compiledProposalValidator = CompiledValidator compiledProposalValidator
+        , Scripts.compiledTreasuryValidator = CompiledValidator compiledTreasuryValidator
+        , Scripts.compiledAuthorityTokenPolicy = CompiledMintingPolicy compiledAuthorityPolicy
+        }

--- a/agora/Agora/Effect.hs
+++ b/agora/Agora/Effect.hs
@@ -8,7 +8,14 @@ Helpers for constructing effects.
 module Agora.Effect (makeEffect) where
 
 import Agora.AuthorityToken (singleAuthorityTokenBurned)
-import Plutarch.Api.V1 (PCurrencySymbol, PScriptPurpose (PSpending), PTxInfo, PTxOutRef, PValidator, PValue)
+import Plutarch.Api.V1 (
+  PCurrencySymbol,
+  PScriptPurpose (PSpending),
+  PTxInfo,
+  PTxOutRef,
+  PValidator,
+  PValue,
+ )
 import Plutarch.Extra.TermCont (pguardC, pletC, pletFieldsC, pmatchC, ptryFromC)
 import Plutarch.TryFrom ()
 import PlutusLedgerApi.V1.Value (CurrencySymbol)

--- a/agora/Agora/Effect.hs
+++ b/agora/Agora/Effect.hs
@@ -23,7 +23,7 @@ import PlutusLedgerApi.V1.Value (CurrencySymbol)
 -}
 makeEffect ::
   forall (datum :: PType).
-  (PTryFrom PData datum) =>
+  (PTryFrom PData datum, PIsData datum) =>
   CurrencySymbol ->
   (forall (s :: S). Term s PCurrencySymbol -> Term s datum -> Term s PTxOutRef -> Term s (PAsData PTxInfo) -> Term s POpaque) ->
   ClosedTerm PValidator

--- a/agora/Agora/Effect.hs
+++ b/agora/Agora/Effect.hs
@@ -23,7 +23,7 @@ import PlutusLedgerApi.V1.Value (CurrencySymbol)
 -}
 makeEffect ::
   forall (datum :: PType).
-  (PIsData datum, PTryFrom PData (PAsData datum)) =>
+  (PTryFrom PData datum) =>
   CurrencySymbol ->
   (forall (s :: S). Term s PCurrencySymbol -> Term s datum -> Term s PTxOutRef -> Term s (PAsData PTxInfo) -> Term s POpaque) ->
   ClosedTerm PValidator
@@ -34,7 +34,7 @@ makeEffect gatCs' f =
     -- convert input datum, PData, into desierable type
     -- the way this conversion is performed should be defined
     -- by PTryFrom for each datum in effect script.
-    (pfromData -> datum', _) <- ptryFromC datum
+    (datum', _) <- ptryFromC datum
 
     -- ensure purpose is Spending.
     PSpending txOutRef <- pmatchC $ pfromData ctx.purpose

--- a/agora/Agora/Effect/GovernorMutation.hs
+++ b/agora/Agora/Effect/GovernorMutation.hs
@@ -26,7 +26,6 @@ import Agora.Governor (
  )
 import Agora.Plutarch.Orphans ()
 import Agora.Scripts (AgoraScripts, authorityTokenSymbol, governorSTAssetClass)
-import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (
   PTxOutRef,
   PValidator,
@@ -66,10 +65,6 @@ data MutateGovernorDatum = MutateGovernorDatum
     , -- | @since 0.1.ç
       Generic
     )
-  deriving anyclass
-    ( -- | @since 0.1.ç
-      SOP.Generic
-    )
 
 PlutusTx.makeIsDataIndexed ''MutateGovernorDatum [('MutateGovernorDatum, 0)]
 
@@ -95,8 +90,6 @@ newtype PMutateGovernorDatum (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Effect/NoOp.hs
+++ b/agora/Agora/Effect/NoOp.hs
@@ -7,11 +7,9 @@ A dumb effect that only burns its GAT.
 -}
 module Agora.Effect.NoOp (noOpValidator, PNoOp) where
 
-import Control.Applicative (Const)
-
 import Agora.Effect (makeEffect)
+import Agora.Plutarch.Orphans ()
 import Plutarch.Api.V1 (PValidator)
-import Plutarch.TryFrom (PTryFrom (..))
 import PlutusLedgerApi.V1.Value (CurrencySymbol)
 
 {- | Dummy datum for NoOp effect.
@@ -19,22 +17,23 @@ import PlutusLedgerApi.V1.Value (CurrencySymbol)
      @since 0.1.0
 -}
 newtype PNoOp (s :: S) = PNoOp (Term s PUnit)
-  deriving
+  deriving stock
+    ( -- | @since 0.2.0
+      Generic
+    )
+  deriving anyclass
     ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     )
-    via (DerivePNewtype PNoOp PUnit)
 
--- | @since 0.1.0
-instance PTryFrom PData (PAsData PNoOp) where
-  type PTryFromExcess PData (PAsData PNoOp) = Const ()
-  ptryFrom' _ cont =
-    -- JUSTIFICATION:
-    -- We don't care anything about data.
-    -- It should always be reduced to Unit.
-    cont (pdata $ pcon $ PNoOp (pconstant ()), ())
+-- | @since 0.2.0
+instance DerivePlutusType PNoOp where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 0.2.0
+instance PTryFrom PData (PAsData PNoOp)
 
 {- | Dummy effect which can only burn its GAT.
 
@@ -42,4 +41,4 @@ instance PTryFrom PData (PAsData PNoOp) where
 -}
 noOpValidator :: CurrencySymbol -> ClosedTerm PValidator
 noOpValidator curr = makeEffect curr $
-  \_ (_datum :: Term s PNoOp) _ _ -> popaque (pconstant ())
+  \_ (_datum :: Term s (PAsData PNoOp)) _ _ -> popaque (pconstant ())

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -15,8 +15,7 @@ module Agora.Effect.TreasuryWithdrawal (
 
 import Agora.Effect (makeEffect)
 import Agora.Plutarch.Orphans ()
-import GHC.Generics qualified as GHC
-import Generics.SOP (Generic, I (I))
+import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (
   AmountGuarantees (Positive),
   KeyGuarantees (Sorted),
@@ -31,7 +30,6 @@ import "plutarch" Plutarch.Api.V1.Value (pnormalize)
 import Plutarch.DataRepr (
   DerivePConstantViaData (..),
   PDataFields,
-  PIsDataReprInstances (..),
  )
 import Plutarch.Extra.TermCont (pguardC, pletC, pletFieldsC, pmatchC)
 import Plutarch.Lift (PConstantDecl, PUnsafeLiftDecl (..))
@@ -57,11 +55,11 @@ data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum
     ( -- | @since 0.1.0
       Show
     , -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      Generic
+      SOP.Generic
     )
 
 -- | @since 0.1.0
@@ -86,23 +84,21 @@ newtype PTreasuryWithdrawalDatum (s :: S)
       )
   deriving stock
     ( -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      Generic
+      SOP.Generic
     , -- | @since 0.1.0
-      PIsDataRepr
-    )
-  deriving
-    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     , -- | @since 0.1.0
       PDataFields
     )
-    via PIsDataReprInstances PTreasuryWithdrawalDatum
+
+instance DerivePlutusType PTreasuryWithdrawalDatum where
+  type DPTStrat _ = PlutusTypeData
 
 -- | @since 0.1.0
 instance PUnsafeLiftDecl PTreasuryWithdrawalDatum where
@@ -115,10 +111,7 @@ deriving via
     (PConstantDecl TreasuryWithdrawalDatum)
 
 -- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PTreasuryWithdrawalDatum)
-  instance
-    PTryFrom PData (PAsData PTreasuryWithdrawalDatum)
+instance PTryFrom PData PTreasuryWithdrawalDatum
 
 {- | Withdraws given list of values to specific target addresses.
      It can be evoked by burning GAT. The transaction should have correct
@@ -150,17 +143,17 @@ treasuryWithdrawalValidator currSymbol = makeEffect currSymbol $
       pletC $
         pmap
           # plam
-            ( \(pfromData -> txOut') -> unTermCont $ do
+            ( \txOut' -> unTermCont $ do
                 txOut <- pletFieldsC @'["address", "value"] $ txOut'
                 let cred = pfield @"credential" # pfromData txOut.address
                 pure . pdata $ ptuple # cred # txOut.value
             )
-          # txInfo.outputs
+          # pfromData txInfo.outputs
     inputValues <-
       pletC $
         pmap
           # plam
-            ( \((pfield @"resolved" #) . pfromData -> txOut') -> unTermCont $ do
+            ( \((pfield @"resolved" #) -> txOut') -> unTermCont $ do
                 txOut <- pletFieldsC @'["address", "value"] $ txOut'
                 let cred = pfield @"credential" # pfromData txOut.address
                 pure . pdata $ ptuple # cred # txOut.value
@@ -189,7 +182,7 @@ treasuryWithdrawalValidator currSymbol = makeEffect currSymbol $
           pnot #$ pany
             # plam
               ( \x ->
-                  effInput.address #== pfield @"address" # pfromData x
+                  effInput.address #== pfield @"address" # x
               )
             # pfromData txInfo.outputs
         inputsAreOnlyTreasuriesOrCollateral =

--- a/agora/Agora/Effect/TreasuryWithdrawal.hs
+++ b/agora/Agora/Effect/TreasuryWithdrawal.hs
@@ -15,7 +15,6 @@ module Agora.Effect.TreasuryWithdrawal (
 
 import Agora.Effect (makeEffect)
 import Agora.Plutarch.Orphans ()
-import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (
   AmountGuarantees (Positive),
   KeyGuarantees (Sorted),
@@ -57,10 +56,6 @@ data TreasuryWithdrawalDatum = TreasuryWithdrawalDatum
     , -- | @since 0.1.0
       Generic
     )
-  deriving anyclass
-    ( -- | @since 0.1.0
-      SOP.Generic
-    )
 
 -- | @since 0.1.0
 PlutusTx.makeLift ''TreasuryWithdrawalDatum
@@ -88,8 +83,6 @@ newtype PTreasuryWithdrawalDatum (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Governor.hs
+++ b/agora/Agora/Governor.hs
@@ -40,7 +40,6 @@ import Agora.Proposal.Time (
  )
 import Agora.SafeMoney (GTTag)
 import Data.Tagged (Tagged (..))
-import Generics.SOP qualified as SOP
 import Plutarch.DataRepr (
   DerivePConstantViaData (..),
   PDataFields,
@@ -114,10 +113,6 @@ data GovernorRedeemer
     , -- | @since 0.2.0
       Bounded
     )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    )
   deriving
     ( -- | @since 0.1.0
       PlutusTx.ToData
@@ -171,10 +166,6 @@ newtype PGovernorDatum (s :: S) = PGovernorDatum
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    )
-  deriving anyclass
-    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -215,8 +206,6 @@ data PGovernorRedeemer (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Plutarch/Orphans.hs
+++ b/agora/Agora/Plutarch/Orphans.hs
@@ -1,15 +1,39 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+{- FIXME: All of the following instances and
+   types ought to belong in either plutarch or
+   plutarch-extra.
+-}
+
 module Agora.Plutarch.Orphans () where
 
-import Plutarch.Api.V1 (PDatumHash)
+import Plutarch.Api.V1 (PDatumHash (..))
 import Plutarch.Builtin (PIsData (..))
+import Plutarch.Extra.TermCont (ptryFromC)
+import Plutarch.TryFrom (PTryFrom (..))
+import Plutarch.Unsafe (punsafeCoerce)
 
--- TODO: add checks
-instance PTryFrom PData (PAsData PDatumHash)
+newtype Flip f a b = Flip (f b a) deriving stock (Generic)
 
+-- | @since 0.1.0
+instance PTryFrom PData (PAsData PDatumHash) where
+  type PTryFromExcess PData (PAsData PDatumHash) = Flip Term PDatumHash
+  ptryFrom' opq = runTermCont $ do
+    (pfromData -> unwrapped, _) <- ptryFromC @(PAsData PByteString) opq
+
+    tcont $ \f ->
+      pif
+        -- Blake2b_256 hash: 256 bits/32 bytes.
+        (plengthBS # unwrapped #== 32)
+        (f ())
+        (ptraceError "ptryFrom(PDatumHash): must be 32 bytes long")
+
+    pure (punsafeCoerce opq, pcon $ PDatumHash unwrapped)
+
+-- | @since 0.2.0
 instance PTryFrom PData (PAsData PUnit)
 
+-- | @since 0.2.0
 instance (PIsData a) => PIsData (PAsData a) where
-  pfromDataImpl = pfromData
+  pfromDataImpl = punsafeCoerce
   pdataImpl = pdataImpl . pfromData

--- a/agora/Agora/Plutarch/Orphans.hs
+++ b/agora/Agora/Plutarch/Orphans.hs
@@ -1,135 +1,15 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-{- FIXME: All of the following instances and
-   types ought to belong in either plutarch or
-   plutarch-extra.
-
-   A number of these have been "stolen" from Mango's
-   PR: https://github.com/Plutonomicon/plutarch/pull/438/
--}
-
 module Agora.Plutarch.Orphans () where
 
-import Control.Arrow (first)
-import Plutarch.Api.V1 (PAddress, PCredential, PCurrencySymbol, PDatumHash, PMap, PMaybeData, PPOSIXTime, PPubKeyHash, PStakingCredential, PTokenName, PTxId, PTxOutRef, PValidatorHash, PValue)
-import Plutarch.Builtin (PBuiltinMap)
-import Plutarch.DataRepr (PIsDataReprInstances (..))
-import Plutarch.Extra.TermCont (ptryFromC)
-import Plutarch.Numeric.Additive (AdditiveSemigroup ((+)))
-import Plutarch.Reducible (Reduce, Reducible)
-import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
-import Plutarch.Unsafe (punsafeCoerce)
-import Prelude hiding ((+))
+import Plutarch.Api.V1 (PDatumHash)
+import Plutarch.Builtin (PIsData (..))
 
-instance Reducible (f x y) => Reducible (Flip f y x) where
-  type Reduce (Flip f y x) = Reduce (f x y)
+-- TODO: add checks
+instance PTryFrom PData (PAsData PDatumHash)
 
-newtype Flip f a b = Flip (f b a)
+instance PTryFrom PData (PAsData PUnit)
 
--- | @since 0.1.0
-instance PTryFrom PData (PAsData b) => PTryFrom PData (PAsData (DerivePNewtype c b)) where
-  type
-    PTryFromExcess PData (PAsData (DerivePNewtype c b)) =
-      PTryFromExcess PData (PAsData b)
-  ptryFrom' d k =
-    ptryFrom' @_ @(PAsData b) d $ k . first punsafeCoerce
-
--- | @since 0.1.0
-instance PTryFrom PData (PAsData PPubKeyHash) where
-  type PTryFromExcess PData (PAsData PPubKeyHash) = Flip Term PPubKeyHash
-  ptryFrom' opq = runTermCont $ do
-    (wrapped :: Term _ (PAsData PByteString), unwrapped :: Term _ PByteString) <-
-      ptryFromC @(PAsData PByteString) opq
-    tcont $ \f -> pif (plengthBS # unwrapped #== 28) (f ()) (ptraceError "a PubKeyHash should be 28 bytes long")
-    pure (punsafeCoerce wrapped, punsafeCoerce unwrapped)
-
--- | @since 0.1.0
-instance AdditiveSemigroup (Term s PPOSIXTime) where
-  (punsafeCoerce @_ @_ @PInteger -> x) + (punsafeCoerce @_ @_ @PInteger -> y) = punsafeCoerce $ x + y
-
--- | @since 0.1.0
-deriving via
-  PAsData (DerivePNewtype PPOSIXTime PInteger)
-  instance
-    PTryFrom PData (PAsData PPOSIXTime)
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PTxId)
-  instance
-    PTryFrom PData (PAsData PTxId)
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PTxOutRef)
-  instance
-    PTryFrom PData (PAsData PTxOutRef)
-
--- | @since 0.1.0
-deriving via
-  PAsData (DerivePNewtype (PMap g k v) (PBuiltinMap k v))
-  instance
-    ( PTryFrom PData (PAsData k)
-    , PTryFrom PData (PAsData v)
-    ) =>
-    PTryFrom PData (PAsData (PMap g k v))
-
--- | @since 0.1.0
-instance PTryFrom PData (PAsData PValidatorHash) where
-  type PTryFromExcess PData (PAsData PValidatorHash) = Flip Term PValidatorHash
-  ptryFrom' opq = runTermCont $ do
-    (wrapped :: Term _ (PAsData PByteString), unwrapped :: Term _ PByteString) <-
-      ptryFromC @(PAsData PByteString) opq
-    tcont $ \f -> pif (plengthBS # unwrapped #== 28) (f ()) (ptraceError "a ValidatorHash should be 28 bytes long")
-    pure (punsafeCoerce wrapped, punsafeCoerce unwrapped)
-
--- | @since 0.1.0
-instance PTryFrom PData (PAsData PDatumHash) where
-  type PTryFromExcess PData (PAsData PDatumHash) = Flip Term PDatumHash
-  ptryFrom' opq = runTermCont $ do
-    (wrapped :: Term _ (PAsData PByteString), unwrapped :: Term _ PByteString) <-
-      tcont $ ptryFrom @(PAsData PByteString) opq
-    tcont $ \f -> pif (plengthBS # unwrapped #== 32) (f ()) (ptraceError "a DatumHash should be 32 bytes long")
-    pure (punsafeCoerce wrapped, punsafeCoerce unwrapped)
-
--- | @since 0.1.0
-deriving via
-  PAsData (DerivePNewtype PCurrencySymbol PByteString)
-  instance
-    PTryFrom PData (PAsData PCurrencySymbol)
-
--- | @since 0.1.0
-deriving via
-  PAsData (DerivePNewtype PTokenName PByteString)
-  instance
-    PTryFrom PData (PAsData PTokenName)
-
--- | @since 0.1.0
-deriving via
-  PAsData (DerivePNewtype (PValue k v) (PMap k PCurrencySymbol (PMap k PTokenName PInteger)))
-  instance
-    PTryFrom PData (PAsData (PValue k v))
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances (PMaybeData a))
-  instance
-    PTryFrom PData (PAsData a) => PTryFrom PData (PAsData (PMaybeData a))
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PAddress)
-  instance
-    PTryFrom PData (PAsData PAddress)
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PCredential)
-  instance
-    PTryFrom PData (PAsData PCredential)
-
--- | @since 0.1.0
-deriving via
-  PAsData (PIsDataReprInstances PStakingCredential)
-  instance
-    PTryFrom PData (PAsData PStakingCredential)
+instance (PIsData a) => PIsData (PAsData a) where
+  pfromDataImpl = pfromData
+  pdataImpl = pdataImpl . pfromData

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -9,7 +9,8 @@ Proposal scripts encoding effects that operate on the system.
 -}
 module Agora.Proposal (
   -- * Haskell-land
-  Proposal (..),
+
+  -- Proposal (..),
   ProposalDatum (..),
   ProposalRedeemer (..),
   ProposalStatus (..),
@@ -76,7 +77,6 @@ import Plutarch.Lift (
 import Plutarch.SafeMoney (PDiscrete (..))
 import Plutarch.Show (PShow (..))
 import PlutusLedgerApi.V1 (DatumHash, PubKeyHash, ValidatorHash)
-import PlutusLedgerApi.V1.Value (AssetClass)
 import PlutusTx qualified
 import PlutusTx.AssocMap qualified as AssocMap
 
@@ -397,29 +397,6 @@ PlutusTx.makeIsDataIndexed
   , ('Unlock, 2)
   , ('AdvanceProposal, 3)
   ]
-
-{- | Parameters that identify the Proposal validator script.
-
-     @since 0.1.0
--}
-data Proposal = Proposal
-  { governorSTAssetClass :: AssetClass
-  , stakeSTAssetClass :: AssetClass
-  , maximumCosigners :: Integer
-  -- ^ Arbitrary limit for maximum amount of cosigners on a proposal.
-  }
-  deriving stock
-    ( -- | @since 0.1.0
-      Show
-    , -- | @since 0.1.0
-      Eq
-    , -- | @since 0.1.0
-      Generic
-    )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    )
 
 --------------------------------------------------------------------------------
 -- Plutarch-land

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -108,10 +108,6 @@ newtype ProposalId = ProposalId {proposalTag :: Integer}
     , -- | @since 0.1.0
       PlutusTx.UnsafeFromData
     )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    )
 
 {- | Encodes a result. Typically, for a Yes/No proposal, we encode it like this:
 
@@ -140,10 +136,6 @@ newtype ResultTag = ResultTag {getResultTag :: Integer}
       PlutusTx.FromData
     , -- | @since 0.1.0
       PlutusTx.UnsafeFromData
-    )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
     )
 
 {- | The "status" of the proposal. This is only useful for state transitions that
@@ -240,7 +232,6 @@ data ProposalThresholds = ProposalThresholds
     , -- | @since 0.1.0
       Generic
     )
-  deriving anyclass (SOP.Generic)
 
 PlutusTx.makeIsDataIndexed 'ProposalThresholds [('ProposalThresholds, 0)]
 
@@ -273,10 +264,6 @@ newtype ProposalVotes = ProposalVotes
       PlutusTx.ToData
     , -- | @since 0.1.0
       PlutusTx.FromData
-    )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
     )
 
 {- | Create a 'ProposalVotes' that has the same shape as the 'effects' field.
@@ -384,10 +371,6 @@ data ProposalRedeemer
     , -- | @since 0.1.0
       Generic
     )
-  deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    )
 
 -- | @since 0.1.0
 PlutusTx.makeIsDataIndexed
@@ -411,9 +394,7 @@ newtype PResultTag (s :: S) = PResultTag (Term s PInteger)
       Generic
     )
   deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    , -- @since 0.1.0
+    ( -- @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -453,9 +434,7 @@ newtype PProposalId (s :: S) = PProposalId (Term s PInteger)
       Generic
     )
   deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    , -- | @since 0.1.0
+    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -508,8 +487,6 @@ data PProposalStatus (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -551,8 +528,6 @@ newtype PProposalThresholds (s :: S) = PProposalThresholds
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -587,9 +562,7 @@ newtype PProposalVotes (s :: S)
       Generic
     )
   deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    , -- | @since 0.1.0
+    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -637,8 +610,6 @@ newtype PProposalDatum (s :: S) = PProposalDatum
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -673,8 +644,6 @@ data PProposalRedeemer (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -31,7 +31,6 @@ module Agora.Proposal.Time (
 ) where
 
 import Control.Composition ((.*))
-import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (
   PExtended (PFinite),
   PInterval (PInterval),
@@ -107,10 +106,6 @@ data ProposalTimingConfig = ProposalTimingConfig
     , -- | @since 0.1.0
       Generic
     )
-  deriving anyclass
-    ( -- | @since 0.1.0
-      SOP.Generic
-    )
 
 PlutusTx.makeIsDataIndexed 'ProposalTimingConfig [('ProposalTimingConfig, 0)]
 
@@ -174,10 +169,6 @@ data PProposalTime (s :: S) = PProposalTime
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
-      SOP.HasDatatypeInfo
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PEq
@@ -194,8 +185,6 @@ newtype PProposalStartingTime (s :: S) = PProposalStartingTime (Term s PPOSIXTim
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -240,8 +229,6 @@ newtype PProposalTimingConfig (s :: S) = PProposalTimingConfig
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -273,9 +260,7 @@ newtype PMaxTimeRangeWidth (s :: S)
       Generic
     )
   deriving anyclass
-    ( -- | @since 0.2.0
-      SOP.Generic
-    , -- | @since 0.1.0
+    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -30,9 +30,7 @@ module Agora.Proposal.Time (
   pisMaxTimeRangeWidthValid,
 ) where
 
-import Agora.Plutarch.Orphans ()
-import GHC.Generics qualified as GHC
-import Generics.SOP (Generic, HasDatatypeInfo, I (I))
+import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (
   PExtended (PFinite),
   PInterval (PInterval),
@@ -44,7 +42,6 @@ import Plutarch.Api.V1 (
 import Plutarch.DataRepr (
   DerivePConstantViaData (..),
   PDataFields,
-  PIsDataReprInstances (..),
  )
 import Plutarch.Extra.Field (pletAllC)
 import Plutarch.Extra.TermCont (pguardC, pmatchC)
@@ -53,10 +50,9 @@ import Plutarch.Lift (
   PConstantDecl,
   PUnsafeLiftDecl (..),
  )
-import Plutarch.Numeric.Additive (AdditiveSemigroup ((+)))
 import PlutusLedgerApi.V1.Time (POSIXTime)
 import PlutusTx qualified
-import Prelude hiding ((+))
+import Prelude
 
 --------------------------------------------------------------------------------
 
@@ -67,8 +63,22 @@ import Prelude hiding ((+))
 newtype ProposalStartingTime = ProposalStartingTime
   { getProposalStartingTime :: POSIXTime
   }
-  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
-  deriving stock (Eq, Show, GHC.Generic)
+  deriving stock
+    ( -- | @since 0.1.0
+      Eq
+    , -- | @since 0.1.0
+      Show
+    , -- | @since 0.1.0
+      Generic
+    )
+  deriving newtype
+    ( -- | @since 0.1.0
+      PlutusTx.ToData
+    , -- | @since 0.1.0
+      PlutusTx.FromData
+    , -- | @since 0.1.0
+      PlutusTx.UnsafeFromData
+    )
 
 {- | Configuration of proposal timings.
 
@@ -92,9 +102,12 @@ data ProposalTimingConfig = ProposalTimingConfig
     , -- | @since 0.1.0
       Show
     , -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
-  deriving anyclass (Generic)
+  deriving anyclass
+    ( -- | @since 0.1.0
+      SOP.Generic
+    )
 
 PlutusTx.makeIsDataIndexed 'ProposalTimingConfig [('ProposalTimingConfig, 0)]
 
@@ -108,7 +121,7 @@ newtype MaxTimeRangeWidth = MaxTimeRangeWidth {getMaxWidth :: POSIXTime}
     , -- | @since 0.1.0
       Ord
     , -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
   deriving newtype
     ( -- | @since 0.1.0
@@ -154,41 +167,47 @@ data PProposalTime (s :: S) = PProposalTime
   }
   deriving stock
     ( -- | @since 0.1.0
-      GHC.Generic
+      Generic
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      Generic
+      SOP.Generic
+    , -- | @since 0.1.0
+      SOP.HasDatatypeInfo
     , -- | @since 0.1.0
       PlutusType
-    , -- | @since 0.1.0
-      HasDatatypeInfo
     , -- | @since 0.1.0
       PEq
     )
 
+instance DerivePlutusType PProposalTime where
+  type DPTStrat _ = PlutusTypeScott
+
 -- | Plutarch-level version of 'ProposalStartingTime'.
 newtype PProposalStartingTime (s :: S) = PProposalStartingTime (Term s PPOSIXTime)
-  deriving
+  deriving stock
     ( -- | @since 0.1.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 0.1.0
+      SOP.Generic
+    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     , -- | @since 0.1.0
       PEq
-    , -- | @since 0.1.0
-      POrd
     )
-    via (DerivePNewtype PProposalStartingTime PPOSIXTime)
+
+instance DerivePlutusType PProposalStartingTime where
+  type DPTStrat _ = PlutusTypeNewtype
 
 -- | @since 0.1.0
 instance PUnsafeLiftDecl PProposalStartingTime where
   type PLifted PProposalStartingTime = ProposalStartingTime
 
-deriving via
-  PAsData (DerivePNewtype PProposalStartingTime PPOSIXTime)
-  instance
-    PTryFrom PData (PAsData PProposalStartingTime)
+instance PTryFrom PData (PAsData PProposalStartingTime)
 
 -- | @since 0.1.0
 deriving via
@@ -214,28 +233,24 @@ newtype PProposalTimingConfig (s :: S) = PProposalTimingConfig
   }
   deriving stock
     ( -- | @since 0.1.0
-      GHC.Generic
-    )
-  deriving anyclass
-    ( -- | @since 0.1.0
       Generic
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      PIsDataRepr
-    )
-  deriving
-    ( -- | @since 0.1.0
+      SOP.Generic
+    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     , -- | @since 0.1.0
       PDataFields
     )
-    via (PIsDataReprInstances PProposalTimingConfig)
+
+instance DerivePlutusType PProposalTimingConfig where
+  type DPTStrat _ = PlutusTypeData
 
 -- | @since 0.1.0
-deriving via PAsData (PIsDataReprInstances PProposalTimingConfig) instance PTryFrom PData (PAsData PProposalTimingConfig)
+instance PTryFrom PData PProposalTimingConfig
 
 -- | @since 0.1.0
 instance PUnsafeLiftDecl PProposalTimingConfig where
@@ -250,20 +265,30 @@ deriving via
 -- | Plutarch-level version of 'MaxTimeRangeWidth'.
 newtype PMaxTimeRangeWidth (s :: S)
   = PMaxTimeRangeWidth (Term s PPOSIXTime)
-  deriving
-    ( -- | @since 0.1.0
+  deriving stock
+    ( -- | @since 0.2.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 0.2.0
+      SOP.Generic
+    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     , -- | @since 0.1.0
       PEq
+    , -- | @since 0.2.0
+      PPartialOrd
     , -- | @since 0.1.0
       POrd
     )
-    via (DerivePNewtype PMaxTimeRangeWidth PPOSIXTime)
+
+instance DerivePlutusType PMaxTimeRangeWidth where
+  type DPTStrat _ = PlutusTypeNewtype
 
 -- | @since 0.1.0
-deriving via PAsData (DerivePNewtype PMaxTimeRangeWidth PPOSIXTime) instance PTryFrom PData (PAsData PMaxTimeRangeWidth)
+instance PTryFrom PData (PAsData PMaxTimeRangeWidth)
 
 -- | @since 0.1.0
 instance PUnsafeLiftDecl PMaxTimeRangeWidth where type PLifted PMaxTimeRangeWidth = MaxTimeRangeWidth

--- a/agora/Agora/Scripts.hs
+++ b/agora/Agora/Scripts.hs
@@ -1,0 +1,138 @@
+{- | Module     : Agora.Scripts
+     Maintainer : connor@mlabs.city
+     Description: Precompiled core scripts and utilities
+
+     Precompiled core scripts and utilities
+-}
+module Agora.Scripts (
+  AgoraScripts (..),
+  governorSTSymbol,
+  governorSTAssetClass,
+  governorValidatorHash,
+  proposalSTSymbol,
+  proposalSTAssetClass,
+  proposalValidatoHash,
+  stakeSTSymbol,
+  stakeSTAssetClass,
+  stakeValidatorHash,
+  authorityTokenSymbol,
+  treasuryValidatorHash,
+) where
+
+import Agora.Governor (GovernorDatum, GovernorRedeemer)
+import Agora.Proposal (ProposalDatum, ProposalRedeemer)
+import Agora.Stake (StakeDatum, StakeRedeemer)
+import Agora.Treasury (TreasuryRedeemer)
+import Agora.Utils (CompiledMintingPolicy (..), CompiledValidator (..), validatorHashToTokenName)
+import Plutarch.Api.V1 (mintingPolicySymbol, validatorHash)
+import PlutusLedgerApi.V1 (CurrencySymbol)
+import PlutusLedgerApi.V1.Scripts (ValidatorHash)
+import PlutusLedgerApi.V1.Value (AssetClass (..))
+
+{- | Precompiled core scripts.
+
+     Including:
+
+    - Governor policy
+    - Governor validator
+    - Proposal policy
+    - Proposal validator
+    - Stake policy
+    - Stake validator
+    - Treasury validator
+    - Authority token policy
+
+     @since 0.2.0
+-}
+data AgoraScripts = AgoraScripts
+  { compiledGovernorPolicy :: CompiledMintingPolicy ()
+  , compiledGovernorValidator :: CompiledValidator GovernorDatum GovernorRedeemer
+  , compiledStakePolicy :: CompiledMintingPolicy ()
+  , compiledStakeValidator :: CompiledValidator StakeDatum StakeRedeemer
+  , compiledProposalPolicy :: CompiledMintingPolicy ()
+  , compiledProposalValidator :: CompiledValidator ProposalDatum ProposalRedeemer
+  , compiledTreasuryValidator :: CompiledValidator () TreasuryRedeemer
+  , compiledAuthorityTokenPolicy :: CompiledMintingPolicy ()
+  }
+
+{- | Get the currency symbol of the governor state token.
+
+     @since 0.2.0
+-}
+governorSTSymbol :: AgoraScripts -> CurrencySymbol
+governorSTSymbol = mintingPolicySymbol . getCompiledMintingPolicy . compiledGovernorPolicy
+
+{- | Get the asset class of the governor state token.
+
+     @since 0.2.0
+-}
+governorSTAssetClass :: AgoraScripts -> AssetClass
+governorSTAssetClass as = AssetClass (governorSTSymbol as, "")
+
+{- | Get the script hash of the governor validator.
+
+     @since 0.2.0
+-}
+governorValidatorHash :: AgoraScripts -> ValidatorHash
+governorValidatorHash = validatorHash . getCompiledValidator . compiledGovernorValidator
+
+{- | Get the currency symbol of the propsoal state token.
+
+     @since 0.2.0
+-}
+proposalSTSymbol :: AgoraScripts -> CurrencySymbol
+proposalSTSymbol as = mintingPolicySymbol $ getCompiledMintingPolicy as.compiledProposalPolicy
+
+{- | Get the asset class of the governor state token.
+
+     @since 0.2.0
+-}
+proposalSTAssetClass :: AgoraScripts -> AssetClass
+proposalSTAssetClass as = AssetClass (proposalSTSymbol as, "")
+
+{- | Get the script hash of the proposal validator.
+
+     @since 0.2.0
+-}
+proposalValidatoHash :: AgoraScripts -> ValidatorHash
+proposalValidatoHash = validatorHash . getCompiledValidator . compiledProposalValidator
+
+{- | Get the script hash of the governor validator.
+
+     @since 0.2.0
+-}
+stakeSTSymbol :: AgoraScripts -> CurrencySymbol
+stakeSTSymbol = mintingPolicySymbol . getCompiledMintingPolicy . compiledStakePolicy
+
+{- | Get the asset class of the stake state token.
+
+     Note that this token is tagged with the hash of the stake validator.
+      See 'Agora.Stake.Script.stakePolicy'.
+
+     @since 0.2.0
+-}
+stakeSTAssetClass :: AgoraScripts -> AssetClass
+stakeSTAssetClass as =
+  let tn = validatorHashToTokenName $ stakeValidatorHash as
+   in AssetClass (stakeSTSymbol as, tn)
+
+{- | Get the script hash of the stake validator.
+
+     @since 0.2.0
+-}
+stakeValidatorHash :: AgoraScripts -> ValidatorHash
+stakeValidatorHash = validatorHash . getCompiledValidator . compiledStakeValidator
+
+{- | Get the currency symbol of the authority token.
+
+     @since 0.2.0
+-}
+authorityTokenSymbol :: AgoraScripts -> CurrencySymbol
+authorityTokenSymbol = mintingPolicySymbol . getCompiledMintingPolicy . compiledAuthorityTokenPolicy
+
+{- | Get the script hash of the treasury validator.
+
+     @since 0.2.0
+-}
+treasuryValidatorHash :: AgoraScripts -> ValidatorHash
+treasuryValidatorHash = validatorHash . getCompiledValidator . compiledTreasuryValidator

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -114,10 +114,6 @@ data ProposalLock
     , -- | @since 0.1.0
       Generic
     )
-  deriving anyclass
-    ( -- | @since 0.1.0
-      SOP.Generic
-    )
 
 PlutusTx.makeIsDataIndexed
   ''ProposalLock
@@ -234,8 +230,6 @@ newtype PStakeDatum (s :: S) = PStakeDatum
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -329,10 +323,6 @@ data PProposalLock (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    , -- | @since 0.1.0
-      SOP.HasDatatypeInfo
-    , -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
@@ -419,11 +409,7 @@ data PStakeRole (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.2.0
-      SOP.Generic
-    , -- | @since 0.2.0
       PlutusType
-    , -- | @since 0.2.0
-      SOP.HasDatatypeInfo
     , -- | @since 0.2.0
       PEq
     )

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -11,7 +11,6 @@ module Agora.Stake (
   -- * Haskell-land
   StakeDatum (..),
   StakeRedeemer (..),
-  Stake (..),
   ProposalLock (..),
 
   -- * Plutarch-land
@@ -54,25 +53,10 @@ import Plutarch.Lift (PConstantDecl, PUnsafeLiftDecl (..))
 import Plutarch.SafeMoney (PDiscrete)
 import Plutarch.Show (PShow (..))
 import PlutusLedgerApi.V1 (PubKeyHash)
-import PlutusLedgerApi.V1.Value (AssetClass)
 import PlutusTx qualified
 import Prelude hiding (Num (..))
 
 --------------------------------------------------------------------------------
-
-{- | Parameters for creating Stake scripts.
-
-     @since 0.1.0
--}
-data Stake = Stake
-  { gtClassRef :: Tagged GTTag AssetClass
-  -- ^ Used when inlining the AssetClass of a 'PDiscrete' in the script code.
-  , proposalSTClass :: AssetClass
-  }
-  deriving stock
-    ( -- | @since 0.1.0
-      Generic
-    )
 
 {- | Locks that are stored in the stake datums for various purposes.
 

--- a/agora/Agora/Stake/Scripts.hs
+++ b/agora/Agora/Stake/Scripts.hs
@@ -17,7 +17,6 @@ import Agora.Stake (
  )
 import Agora.Utils (
   mustFindDatum',
-  pvalidatorHashToTokenName,
  )
 import Data.Function (on)
 import Data.Tagged (Tagged (..), untag)
@@ -46,6 +45,7 @@ import Plutarch.SafeMoney (
   pdiscreteValue',
   pvalueDiscrete',
  )
+import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V1.Value (AssetClass (AssetClass))
 import Prelude hiding (Num (..))
 
@@ -135,7 +135,7 @@ stakePolicy gtClassRef =
                                 PPubKeyCredential _ -> pcon PFalse
                                 PScriptCredential ((pfield @"_0" #) -> validatorHash) ->
                                   let tn :: Term _ PTokenName
-                                      tn = pvalidatorHashToTokenName validatorHash
+                                      tn = punsafeCoerce $ pfromData validatorHash
                                    in pvalueOf # outputF.value # ownSymbol # tn #== 1
                         )
                       # pfromData txInfoF.outputs

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -11,14 +11,16 @@ treasury.
 module Agora.Treasury (module Agora.Treasury) where
 
 import Agora.AuthorityToken (singleAuthorityTokenBurned)
-import GHC.Generics qualified as GHC
-import Generics.SOP (Generic)
+import Generics.SOP qualified as SOP
 import Plutarch.Api.V1 (PValidator)
 import Plutarch.Api.V1.Contexts (PScriptPurpose (PMinting))
 import "plutarch" Plutarch.Api.V1.Value (PValue)
 import Plutarch.Builtin (pforgetData)
-import Plutarch.Extra.IsData (DerivePConstantViaEnum (..), EnumIsData (..))
-import Plutarch.Extra.Other (DerivePNewtype' (..))
+import Plutarch.Extra.IsData (
+  DerivePConstantViaEnum (..),
+  EnumIsData (..),
+  PlutusTypeEnumData,
+ )
 import Plutarch.Extra.TermCont (pguardC, pletC, pletFieldsC, pmatchC)
 import Plutarch.Lift (PConstantDecl (..), PLifted (..), PUnsafeLiftDecl)
 import Plutarch.TryFrom ()
@@ -38,7 +40,7 @@ data TreasuryRedeemer
     , -- | @since 0.1.0
       Show
     , -- | @since 0.1.0
-      GHC.Generic
+      Generic
     , -- | @since 0.2.0
       Enum
     , -- | @since 0.2.0
@@ -46,7 +48,7 @@ data TreasuryRedeemer
     )
   deriving anyclass
     ( -- | @since 0.2.0
-      Generic
+      SOP.Generic
     )
   deriving
     ( -- | @since 0.1.0
@@ -63,23 +65,29 @@ data TreasuryRedeemer
 
      @since 0.1.0
 -}
-newtype PTreasuryRedeemer (s :: S)
-  = PTreasuryRedeemer (Term s PInteger)
+data PTreasuryRedeemer (s :: S)
+  = PSpendTreasuryGAT
   deriving stock
     ( -- | @since 0.1.0
-      GHC.Generic
+      Generic
+    , -- | @since 0.2.0
+      Bounded
+    , -- | @since 0.2.0
+      Enum
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      Generic
+      SOP.Generic
     )
-  deriving
+  deriving anyclass
     ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData
     )
-    via (DerivePNewtype' PTreasuryRedeemer)
+
+instance DerivePlutusType PTreasuryRedeemer where
+  type DPTStrat _ = PlutusTypeEnumData
 
 -- | @since 0.1.0
 instance PUnsafeLiftDecl PTreasuryRedeemer where

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -77,10 +77,6 @@ data PTreasuryRedeemer (s :: S)
     )
   deriving anyclass
     ( -- | @since 0.1.0
-      SOP.Generic
-    )
-  deriving anyclass
-    ( -- | @since 0.1.0
       PlutusType
     , -- | @since 0.1.0
       PIsData

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 {- |
 Module     : Agora.Utils
@@ -30,6 +31,7 @@ module Agora.Utils (
   pdnothing,
 ) where
 
+import Data.Default (Default (def))
 import Plutarch.Api.V1 (
   AmountGuarantees,
   KeyGuarantees,
@@ -139,7 +141,7 @@ pvalidatorHashToTokenName vh = pcon (PTokenName (pto vh))
      @since 0.1.0
 -}
 getMintingPolicySymbol :: ClosedTerm PMintingPolicy -> CurrencySymbol
-getMintingPolicySymbol v = mintingPolicySymbol $ mkMintingPolicy v
+getMintingPolicySymbol v = mintingPolicySymbol $ mkMintingPolicy def v
 
 {- | The entire value only contains one token of the given currency symbol.
 
@@ -159,7 +161,7 @@ hasOnlyOneTokenOfCurrencySymbol = phoistAcyclic $
 -}
 mustFindDatum' ::
   forall (datum :: PType).
-  (PIsData datum, PTryFrom PData (PAsData datum)) =>
+  (PIsData datum, PTryFrom PData datum) =>
   forall s.
   Term
     s
@@ -172,7 +174,7 @@ mustFindDatum' = phoistAcyclic $
     let dh = mustBePDJust # "Given TxOut dones't have a datum" # mdh
         dt = mustBePJust # "Datum not found in the transaction" #$ plookupTuple # dh # datums
     (d, _) <- ptryFromC $ pforgetData $ pdata dt
-    pure $ pfromData d
+    pure d
 
 {- | Extract the value stored in a PMaybe container.
      If there's no value, throw an error with the given message.

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -9,117 +9,41 @@ Description: Plutarch utility functions that should be upstreamed or don't belon
 Plutarch utility functions that should be upstreamed or don't belong anywhere else.
 -}
 module Agora.Utils (
-  scriptHashFromAddress,
-  findOutputsToAddress,
-  findTxOutDatum,
   validatorHashToTokenName,
   pvalidatorHashToTokenName,
-  getMintingPolicySymbol,
-  hasOnlyOneTokenOfCurrencySymbol,
   mustFindDatum',
-  mustBePJust,
-  mustBePDJust,
   validatorHashToAddress,
-  isScriptAddress,
-  isPubKey,
   pltAsData,
-  pon,
   withBuiltinPairAsData,
-  pmaybeData,
-  pmaybe,
-  pdjust,
-  pdnothing,
+  CompiledValidator (..),
+  CompiledMintingPolicy (..),
+  CompiledEffect (..),
 ) where
 
-import Data.Default (Default (def))
 import Plutarch.Api.V1 (
-  AmountGuarantees,
-  KeyGuarantees,
-  PAddress,
-  PCredential (PScriptCredential),
-  PCurrencySymbol,
   PDatum,
   PDatumHash,
-  PMaybeData (PDJust, PDNothing),
-  PMintingPolicy,
+  PMaybeData,
   PTokenName (PTokenName),
   PTuple,
-  PTxOut,
   PValidatorHash,
-  PValue,
-  mintingPolicySymbol,
-  mkMintingPolicy,
  )
-import Plutarch.Api.V1.ScriptContext (pfindDatum)
-import "liqwid-plutarch-extra" Plutarch.Api.V1.Value (psymbolValueOf)
 import Plutarch.Builtin (pforgetData)
 import Plutarch.Extra.List (plookupTuple)
-import Plutarch.Extra.TermCont (pletC, pmatchC, ptryFromC)
+import Plutarch.Extra.Maybe (passertPDJust, passertPJust)
+import Plutarch.Extra.TermCont (ptryFromC)
 import PlutusLedgerApi.V1 (
   Address (..),
   Credential (..),
-  CurrencySymbol,
+  MintingPolicy,
   TokenName (..),
+  Validator,
   ValidatorHash (..),
  )
 
 {- Functions which should (probably) not be upstreamed
    All of these functions are quite inefficient.
 -}
-
-{- | Get script hash from an Address.
-
-     @since 0.1.0
--}
-scriptHashFromAddress :: Term s (PAddress :--> PMaybe PValidatorHash)
-scriptHashFromAddress = phoistAcyclic $
-  plam $ \addr ->
-    pmatch (pfromData $ pfield @"credential" # addr) $ \case
-      PScriptCredential ((pfield @"_0" #) -> h) -> pcon $ PJust h
-      _ -> pcon PNothing
-
-{- | Return true if the given address is a script address.
-
-     @since 0.1.0
--}
-isScriptAddress :: Term s (PAddress :--> PBool)
-isScriptAddress = phoistAcyclic $
-  plam $ \addr -> pnot #$ isPubKey #$ pfromData $ pfield @"credential" # addr
-
-{- | Return true if the given credential is a pub-key-hash.
-
-     @since 0.1.0
--}
-isPubKey :: Term s (PCredential :--> PBool)
-isPubKey = phoistAcyclic $
-  plam $ \cred ->
-    pmatch cred $ \case
-      PScriptCredential _ -> pconstant False
-      _ -> pconstant True
-
-{- | Find all TxOuts sent to an Address
-
-     @since 0.1.0
--}
-findOutputsToAddress :: Term s (PBuiltinList (PAsData PTxOut) :--> PAddress :--> PBuiltinList (PAsData PTxOut))
-findOutputsToAddress = phoistAcyclic $
-  plam $ \outputs address' -> unTermCont $ do
-    address <- pletC $ pdata address'
-    pure $
-      pfilter # plam (\(pfromData -> txOut) -> pfield @"address" # txOut #== address)
-        # outputs
-
-{- | Find the data corresponding to a TxOut, if there is one
-
-     @since 0.1.0
--}
-findTxOutDatum :: Term s (PBuiltinList (PAsData (PTuple PDatumHash PDatum)) :--> PTxOut :--> PMaybe PDatum)
-findTxOutDatum = phoistAcyclic $
-  plam $ \datums out -> unTermCont $ do
-    datumHash' <- pmatchC $ pfromData $ pfield @"datumHash" # out
-    pure $ case datumHash' of
-      PDJust ((pfield @"_0" #) -> datumHash) -> pfindDatum # datumHash # datums
-      _ -> pcon PNothing
 
 {- | Safely convert a 'PValidatorHash' into a 'PTokenName'. This can be useful for tagging
      tokens for extra safety.
@@ -135,25 +59,6 @@ validatorHashToTokenName (ValidatorHash hash) = TokenName hash
 -}
 pvalidatorHashToTokenName :: forall (s :: S). Term s PValidatorHash -> Term s PTokenName
 pvalidatorHashToTokenName vh = pcon (PTokenName (pto vh))
-
-{- | Get the CurrencySymbol of a PMintingPolicy.
-
-     @since 0.1.0
--}
-getMintingPolicySymbol :: ClosedTerm PMintingPolicy -> CurrencySymbol
-getMintingPolicySymbol v = mintingPolicySymbol $ mkMintingPolicy def v
-
-{- | The entire value only contains one token of the given currency symbol.
-
-     @since 0.1.0
--}
-hasOnlyOneTokenOfCurrencySymbol ::
-  forall (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S).
-  Term s (PCurrencySymbol :--> PValue keys amounts :--> PBool)
-hasOnlyOneTokenOfCurrencySymbol = phoistAcyclic $
-  plam $ \cs vs -> P.do
-    psymbolValueOf # cs # vs #== 1
-      #&& (plength #$ pto $ pto $ pto vs) #== 1
 
 {- | Find datum given a maybe datum hash
 
@@ -171,32 +76,10 @@ mustFindDatum' ::
     )
 mustFindDatum' = phoistAcyclic $
   plam $ \mdh datums -> unTermCont $ do
-    let dh = mustBePDJust # "Given TxOut dones't have a datum" # mdh
-        dt = mustBePJust # "Datum not found in the transaction" #$ plookupTuple # dh # datums
+    let dh = passertPDJust # "Given TxOut dones't have a datum" # mdh
+        dt = passertPJust # "Datum not found in the transaction" #$ plookupTuple # dh # datums
     (d, _) <- ptryFromC $ pforgetData $ pdata dt
     pure d
-
-{- | Extract the value stored in a PMaybe container.
-     If there's no value, throw an error with the given message.
-
-     @since 0.1.0
--}
-mustBePJust :: forall a s. Term s (PString :--> PMaybe a :--> a)
-mustBePJust = phoistAcyclic $
-  plam $ \emsg mv' -> pmatch mv' $ \case
-    PJust v -> v
-    _ -> ptraceError emsg
-
-{- | Extract the value stored in a PMaybeData container.
-     If there's no value, throw an error with the given message.
-
-     @since 0.1.0
--}
-mustBePDJust :: forall a s. (PIsData a) => Term s (PString :--> PMaybeData a :--> a)
-mustBePDJust = phoistAcyclic $
-  plam $ \emsg mv' -> pmatch mv' $ \case
-    PDJust ((pfield @"_0" #) -> v) -> v
-    _ -> ptraceError emsg
 
 {- | Create an 'Address' from a given 'ValidatorHash' with no 'PlutusLedgerApi.V1.Credential.StakingCredential'.
 
@@ -217,19 +100,6 @@ pltAsData = phoistAcyclic $
   plam $
     \(pfromData -> l) (pfromData -> r) -> l #< r
 
-{- | Plutarch level 'Data.Function.on'.
-
-     @since 0.2.0
--}
-pon ::
-  forall (a :: PType) (b :: PType) (c :: PType) (s :: S).
-  Term s ((b :--> b :--> c) :--> (a :--> b) :--> a :--> a :--> c)
-pon = phoistAcyclic $
-  plam $ \f g x y ->
-    let a = g # x
-        b = g # y
-     in f # a # b
-
 {- | Extract data stored in a 'PBuiltinPair' and call a function to process it.
 
      @since 0.2.0
@@ -247,53 +117,26 @@ withBuiltinPairAsData f p =
       b = pfromData $ psndBuiltin # p
    in f a b
 
-{- | Plutarch version of 'Data.Maybe.maybe'. Take a default value and a function
-      @f@. If the given 'PMaybe' value is @'PJust' x@, apply the function @f@ to
-      @x@, otherewise the default value will be retuned.
+{- | Type-safe wrapper for compiled plutus validator.
 
      @since 0.2.0
 -}
-pmaybe ::
-  forall (a :: PType) (b :: PType) (s :: S).
-  Term s (b :--> (a :--> b) :--> PMaybe a :--> b)
-pmaybe = phoistAcyclic $
-  plam $ \n f m -> pmatch m $ \case
-    PJust x -> f # x
-    _ -> n
+newtype CompiledValidator (datum :: Type) (redeemer :: Type) = CompiledValidator
+  { getCompiledValidator :: Validator
+  }
 
-{- | Special version of 'pmaybe' that works with 'PMaybedata'.
+{- | Type-safe wrapper for compiled plutus miting policy.
 
      @since 0.2.0
 -}
-pmaybeData ::
-  forall (a :: PType) (b :: PType) (s :: S).
-  PIsData a =>
-  Term s (b :--> (a :--> b) :--> PMaybeData a :--> b)
-pmaybeData = phoistAcyclic $
-  plam $ \n f m -> pmatch m $ \case
-    PDJust ((pfield @"_0" #) -> x) -> f # x
-    _ -> n
+newtype CompiledMintingPolicy (redeemer :: Type) = CompiledMintingPolicy
+  { getCompiledMintingPolicy :: MintingPolicy
+  }
 
-{- Construct a 'PDJust' value.
+{- | Type-safe wrapper for compiled plutus effect.
 
-    @since 0.2.0
+     @since 0.2.0
 -}
-pdjust ::
-  forall (a :: PType) (s :: S).
-  (PIsData a) =>
-  Term s (a :--> PMaybeData a)
-pdjust = phoistAcyclic $
-  plam $ \x ->
-    pcon $
-      PDJust $
-        pdcons @"_0" # pdata x #$ pdnil
-
-{- Construct a 'PDNothing' value.
-
-    @since 0.2.0
--}
-pdnothing ::
-  forall (a :: PType) (s :: S).
-  (PIsData a) =>
-  Term s (PMaybeData a)
-pdnothing = phoistAcyclic $ pcon $ PDNothing pdnil
+newtype CompiledEffect (datum :: Type) = CompiledEffect
+  { getCompiledEffect :: Validator
+  }

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -10,7 +10,6 @@ Plutarch utility functions that should be upstreamed or don't belong anywhere el
 -}
 module Agora.Utils (
   validatorHashToTokenName,
-  pvalidatorHashToTokenName,
   mustFindDatum',
   validatorHashToAddress,
   pltAsData,
@@ -24,9 +23,7 @@ import Plutarch.Api.V1 (
   PDatum,
   PDatumHash,
   PMaybeData,
-  PTokenName (PTokenName),
   PTuple,
-  PValidatorHash,
  )
 import Plutarch.Builtin (pforgetData)
 import Plutarch.Extra.List (plookupTuple)
@@ -52,13 +49,6 @@ import PlutusLedgerApi.V1 (
 -}
 validatorHashToTokenName :: ValidatorHash -> TokenName
 validatorHashToTokenName (ValidatorHash hash) = TokenName hash
-
-{- | Plutarch level 'validatorHashToTokenName'.
-
-     @since 0.1.0
--}
-pvalidatorHashToTokenName :: forall (s :: S). Term s PValidatorHash -> Term s PTokenName
-pvalidatorHashToTokenName vh = pcon (PTokenName (pto vh))
 
 {- | Find datum given a maybe datum hash
 

--- a/bench.csv
+++ b/bench.csv
@@ -1,582 +1,582 @@
 name,cpu,mem,size
-Agora/Effects/Treasury Withdrawal Effect/effect/Simple,12736207,40996,2908
-Agora/Effects/Treasury Withdrawal Effect/effect/Simple with multiple treasuries ,12736207,40996,3220
-Agora/Effects/Treasury Withdrawal Effect/effect/Mixed Assets,12736207,40996,3093
-Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/governor validator should pass,108270758,296852,6444
-Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/effect validator should pass,7973222,20696,3222
-Agora/Stake/policy/stakeCreation,53357294,155623,2050
-Agora/Stake/validator/stakeDepositWithdraw deposit,187795456,518604,3825
-Agora/Stake/validator/stakeDepositWithdraw withdraw,187795456,518604,3813
-Agora/Stake/validator/set delegate/override existing delegate,100639801,266338,3877
-Agora/Stake/validator/set delegate/remove existing delegate,98230359,259005,3814
-Agora/Stake/validator/set delegate/set delegate to something,100539113,266338,3814
-Agora/Proposal/policy (proposal creation)/legal/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/legal/governor,354848880,943893,6928
-Agora/Proposal/policy (proposal creation)/legal/stake,153933633,408520,4479
-Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/stake,153933633,408520,4479
-Agora/Proposal/policy (proposal creation)/illegal/use other's stake/proposal,33873644,101086,1811
-Agora/Proposal/policy (proposal creation)/illegal/use other's stake/governor,354848880,943893,6897
-Agora/Proposal/policy (proposal creation)/illegal/altered stake/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/proposal,33873644,101086,1850
-Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/stake,159367293,423170,4487
-Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/proposal,33873644,101086,1862
-Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/stake,160396125,426628,4509
-Agora/Proposal/policy (proposal creation)/illegal/loose time range/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/loose time range/stake,153933633,408520,4479
-Agora/Proposal/policy (proposal creation)/illegal/open time range/proposal,33873644,101086,1838
-Agora/Proposal/policy (proposal creation)/illegal/open time range/stake,153933633,408520,4475
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/stake,153933633,408520,4479
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/stake,153933633,408520,4479
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/proposal,33873644,101086,1842
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/stake,153933633,408520,4479
-Agora/Proposal/validator/cosignature/legal/with 1 cosigners/proposal,270612694,756318,6994
-Agora/Proposal/validator/cosignature/legal/with 1 cosigners/stake,120950501,317982,4287
-Agora/Proposal/validator/cosignature/legal/with 5 cosigners/proposal,711284625,1983397,9648
-Agora/Proposal/validator/cosignature/legal/with 5 cosigners/stake,552610861,1480482,6821
-Agora/Proposal/validator/cosignature/legal/with 10 cosigners/proposal,1413916463,3893380,12967
-Agora/Proposal/validator/cosignature/legal/with 10 cosigners/stake,1187840396,3209013,9989
-Agora/Proposal/validator/cosignature/illegal/duplicate cosigners/stake,120950501,317982,4287
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: VotingReady/stake,120950501,317982,4287
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Locked/stake,120950501,317982,4287
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Finished/stake,120950501,317982,4287
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: VotingReady/stake,552610861,1480482,6821
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Locked/stake,552610861,1480482,6821
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Finished/stake,552610861,1480482,6821
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: VotingReady/stake,1187840396,3209013,9989
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Locked/stake,1187840396,3209013,9989
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Finished/stake,1187840396,3209013,9989
-Agora/Proposal/validator/voting/legal/ordinary/proposal,292107030,818192,6976
-Agora/Proposal/validator/voting/legal/ordinary/stake,138776145,368604,4313
-Agora/Proposal/validator/voting/legal/delegate/proposal,293223020,821804,7039
-Agora/Proposal/validator/voting/legal/delegate/stake,135207796,352770,4407
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,278165358,776398,7489
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,4623
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,323181211,887380,7498
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,4630
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,373749316,1029579,8650
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,5782
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,495323391,1250397,8245
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3342
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,275372622,770485,7491
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,4625
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,311464859,854847,7492
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,4626
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,313726815,859655,7492
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,4626
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,4623
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,4630
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,5782
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3342
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient cosigns/stake,132049602,347450,4623
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,4626
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,4634
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,132049602,347450,4625
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,4630
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,5782
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,495323391,1250397,8245
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3342
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,495323391,1250397,8246
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3343
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/proposal,349498270,956970,7939
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5071
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,381832998,1053782,8877
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6009
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3569
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,373749316,1029579,8472
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5604
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/proposal,373749316,1029579,8644
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,5776
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3336
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/proposal,373749316,1029579,8650
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,5782
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3342
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,318054305,881782,8078
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,5016
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,366765044,1002752,8087
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5023
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,413638263,1134963,9240
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6176
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,513404095,1300606,8639
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3736
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,315261569,875869,8080
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5018
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,351353806,960231,8081
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5019
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,353615762,965039,8081
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5019
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,5016
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5023
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6176
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3736
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient cosigns/stake,132049602,347450,5016
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5019
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5031
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,132049602,347450,5018
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5023
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6176
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,513404095,1300606,8639
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3736
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,513404095,1300606,8640
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3737
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/proposal,389387217,1062354,8528
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,5464
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,421721945,1159166,9467
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6403
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3963
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,413638263,1134963,9061
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5997
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/proposal,413638263,1134963,9234
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6170
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,3730
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/proposal,413638263,1134963,9240
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6176
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,3736
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,437721146,1197934,9850
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,6197
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,497516543,1348868,9859
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6204
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,533305104,1451115,11011
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7356
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,567646207,1451233,9819
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,4916
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,434928410,1192021,9852
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6199
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,471020647,1276383,9853
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6200
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,473282603,1281191,9853
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6200
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,6197
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6204
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7356
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,4916
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient cosigns/stake,132049602,347450,6197
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6200
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6224
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,132049602,347450,6199
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6204
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7356
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,567646207,1451233,9819
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,4916
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,567646207,1451233,9820
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,4917
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/proposal,509054058,1378506,10300
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,6645
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,541388786,1475318,11238
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,7583
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5143
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,533305104,1451115,10833
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7178
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/proposal,533305104,1451115,11005
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7350
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,4910
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/proposal,533305104,1451115,11011
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7356
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,4916
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,648239449,1844807,10259
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,7272
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,345550559,949444,7855
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,4866
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,396118664,1091643,9007
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6018
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,502511339,1271085,8482
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3579
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,297741970,832549,7848
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,4861
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,333834207,916911,7849
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,4862
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,336096163,921719,7849
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,4862
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,7272
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,4866
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6018
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3579
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient cosigns/stake,536963978,1432062,7272
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,4862
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,4870
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,7274
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,4866
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6018
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,502511339,1271085,8482
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3579
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,502511339,1271085,8483
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3580
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/proposal,371867618,1019034,8295
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5306
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,404202346,1115846,9234
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6245
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3806
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,396118664,1091643,8829
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5840
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/proposal,396118664,1091643,9001
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,6012
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3573
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/proposal,396118664,1091643,9007
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,6018
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3579
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,688128396,1950191,10850
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,7666
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,389134392,1064816,8445
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5259
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,436007611,1197027,9598
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6412
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,520592043,1321294,8876
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3973
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,337630917,937933,8438
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5254
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,373723154,1022295,8439
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5255
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,375985110,1027103,8439
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5255
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,7666
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5259
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6412
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3973
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient cosigns/stake,536963978,1432062,7666
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5255
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5267
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,7668
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5259
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6412
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,520592043,1321294,8876
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3973
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,520592043,1321294,8877
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3974
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/proposal,411756565,1124418,8886
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,5700
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,444091293,1221230,9825
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6639
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4200
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,436007611,1197027,9419
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6233
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/proposal,436007611,1197027,9592
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6406
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,3967
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/proposal,436007611,1197027,9598
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6412
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,3973
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,807795237,2266343,12620
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,8846
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,519885891,1410932,10216
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6440
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,555674452,1513179,11368
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7592
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,574834155,1471921,10056
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,5153
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,457297758,1254085,10209
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6435
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,493389995,1338447,10210
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6436
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,495651951,1343255,10210
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6436
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,8846
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6440
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7592
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,5153
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient cosigns/stake,536963978,1432062,8846
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6436
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6460
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,8848
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6440
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7592
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,574834155,1471921,10056
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,5153
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,574834155,1471921,10057
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,5154
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/proposal,531423406,1440570,10657
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,6881
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,563758134,1537382,11595
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,7819
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5380
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,555674452,1513179,11190
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7414
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/proposal,555674452,1513179,11362
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7586
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,5147
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/proposal,555674452,1513179,11368
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7592
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,5153
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,1198176494,3435790,13728
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,10590
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,373512244,1027024,8307
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5167
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,424080349,1169223,9459
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6319
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,511496274,1296945,8783
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3880
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,325703655,910129,8300
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5162
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,361795892,994491,8301
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5163
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,364057848,999299,8301
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5163
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,10590
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5167
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6319
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3880
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient cosigns/stake,1201163379,3244679,10590
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,5163
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,5171
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,10592
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5167
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6319
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,511496274,1296945,8783
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3880
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,511496274,1296945,8784
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3881
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/proposal,399829303,1096614,8748
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5608
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,432164031,1193426,9686
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6546
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4107
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,424080349,1169223,9281
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6141
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/proposal,424080349,1169223,9453
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,6313
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3874
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/proposal,424080349,1169223,9459
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,6319
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3880
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,1238065441,3541174,14318
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,10984
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,417096077,1142396,8896
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5560
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,463969296,1274607,10049
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6713
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,529576978,1347154,9177
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,4274
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,365592602,1015513,8889
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5555
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,401684839,1099875,8890
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5556
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,403946795,1104683,8890
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5556
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,10984
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5560
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6713
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,4274
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient cosigns/stake,1201163379,3244679,10984
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5556
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5568
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,10986
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5560
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6713
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,529576978,1347154,9177
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,4274
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,529576978,1347154,9178
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,4275
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/proposal,439718250,1201998,9337
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,6001
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,472052978,1298810,10276
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6940
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4501
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,463969296,1274607,9870
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6534
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/proposal,463969296,1274607,10043
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6707
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,4268
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/proposal,463969296,1274607,10049
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6713
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,4274
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,1357732282,3857326,16089
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,12164
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,547847576,1488512,10668
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6741
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,583636137,1590759,11821
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7894
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,583819090,1497781,10358
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,5455
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,485259443,1331665,10661
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6736
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,521351680,1416027,10662
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6737
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,523613636,1420835,10662
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6737
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,12164
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6741
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7894
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,5455
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient cosigns/stake,1201163379,3244679,12164
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6737
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6761
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,12166
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6741
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7894
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,583819090,1497781,10358
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,5455
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,583819090,1497781,10359
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,5456
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/proposal,559385091,1518150,11109
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,7182
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,591719819,1614962,12047
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,8120
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5681
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,583636137,1590759,11642
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7715
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/proposal,583636137,1590759,11815
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7888
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,5448
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/proposal,583636137,1590759,11821
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7894
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,5455
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/stake,126576208,334351,4293
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/proposal,48129948,145642,6957
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/stake,129807454,343405,4309
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,6968
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/stake,126576208,334351,4291
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/proposal,48129948,145642,6954
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/stake,126576208,334351,4307
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,6966
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/stake,126576208,334351,4297
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,6961
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/stake,126576208,334351,4297
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,6961
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/stake,129807454,343405,4313
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,6972
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/stake,282885452,734987,6386
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/proposal,48129948,145642,9026
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/stake,299041682,780257,6462
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,9077
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/stake,282885452,734987,6375
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/proposal,48129948,145642,9018
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/stake,282885452,734987,6456
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,9071
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/stake,282885452,734987,6406
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,9046
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/stake,282885452,734987,6406
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,9046
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/stake,299041682,780257,6482
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,9097
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/stake,478272007,1235782,9001
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/proposal,48129948,145642,11611
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/stake,510584467,1326322,9152
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,11712
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/stake,478272007,1235782,8981
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/proposal,48129948,145642,11599
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/stake,478272007,1235782,9141
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,11701
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/stake,478272007,1235782,9041
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,11651
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/stake,478272007,1235782,9041
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,11651
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/stake,510584467,1326322,9192
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,11752
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/stake,1728745959,4440870,25831
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/proposal,48129948,145642,28230
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/stake,1864458291,4821138,26518
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,28688
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/stake,1728745959,4440870,25746
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/proposal,48129948,145642,28185
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/stake,1728745959,4440870,26457
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,28627
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/stake,1728745959,4440870,25999
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,28398
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/stake,1728745959,4440870,25999
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,28398
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/stake,1864458291,4821138,26687
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,28857
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Draft/stake",126576208,334351,4293
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Locked/stake",126576208,334351,4293
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Finished/stake",126576208,334351,4293
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Draft/stake",122205622,322501,4295
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Locked/stake",122205622,322501,4295
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Finished/stake",122205622,322501,4295
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Draft/stake",129807454,343405,4309
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Locked/stake",129807454,343405,4309
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Finished/stake",129807454,343405,4309
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",118974376,313447,4275
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",118974376,313447,4275
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,118974376,313447,4275
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Draft/stake,126576208,334351,4291
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: VotingReady/stake,126576208,334351,4291
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Locked/stake,126576208,334351,4291
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/creator: retract votes/stake,126576208,334351,4289
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Draft/stake",282885452,734987,6386
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Locked/stake",282885452,734987,6386
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Finished/stake",282885452,734987,6386
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Draft/stake",276236186,717545,6392
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Locked/stake",276236186,717545,6392
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Finished/stake",276236186,717545,6392
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Draft/stake",299041682,780257,6462
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Locked/stake",299041682,780257,6462
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Finished/stake",299041682,780257,6462
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",260079956,672275,6303
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",260079956,672275,6303
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,260079956,672275,6303
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Draft/stake,282885452,734987,6375
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: VotingReady/stake,282885452,734987,6375
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Locked/stake,282885452,734987,6375
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/creator: retract votes/stake,282885452,734987,6365
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Draft/stake",478272007,1235782,9001
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Locked/stake",478272007,1235782,9001
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Finished/stake",478272007,1235782,9001
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Draft/stake",468774391,1211350,9012
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Locked/stake",468774391,1211350,9012
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Finished/stake",468774391,1211350,9012
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Draft/stake",510584467,1326322,9152
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Locked/stake",510584467,1326322,9152
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Finished/stake",510584467,1326322,9152
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",436461931,1120810,8838
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",436461931,1120810,8838
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,436461931,1120810,8838
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Draft/stake,478272007,1235782,8981
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: VotingReady/stake,478272007,1235782,8981
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Locked/stake,478272007,1235782,8981
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/creator: retract votes/stake,478272007,1235782,8960
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Draft/stake",1728745959,4440870,25831
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Locked/stake",1728745959,4440870,25831
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Finished/stake",1728745959,4440870,25831
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Draft/stake",1701018903,4371702,25892
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Locked/stake",1701018903,4371702,25892
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Finished/stake",1701018903,4371702,25892
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Draft/stake",1864458291,4821138,26518
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Locked/stake",1864458291,4821138,26518
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Finished/stake",1864458291,4821138,26518
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",1565306571,3991434,25118
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",1565306571,3991434,25118
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,1565306571,3991434,25118
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Draft/stake,1728745959,4440870,25746
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: VotingReady/stake,1728745959,4440870,25746
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Locked/stake,1728745959,4440870,25746
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/creator: retract votes/stake,1728745959,4440870,25662
+Agora/Effects/Treasury Withdrawal Effect/effect/Simple,380214695,980182,4275
+Agora/Effects/Treasury Withdrawal Effect/effect/Simple with multiple treasuries ,544143721,1366494,4691
+Agora/Effects/Treasury Withdrawal Effect/effect/Mixed Assets,545045362,1387355,4636
+Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/governor validator should pass,112721874,312363,9413
+Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/effect validator should pass,152563857,422397,4692
+Agora/Stake/policy/stakeCreation,54323406,159125,2646
+Agora/Stake/validator/stakeDepositWithdraw deposit,194804304,538628,5315
+Agora/Stake/validator/stakeDepositWithdraw withdraw,194804304,538628,5303
+Agora/Stake/validator/set delegate/override existing delegate,117949415,309090,5367
+Agora/Stake/validator/set delegate/remove existing delegate,115539973,301757,5304
+Agora/Stake/validator/set delegate/set delegate to something,114218077,301022,5304
+Agora/Proposal/policy (proposal creation)/legal/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/legal/governor,369498544,984529,9918
+Agora/Proposal/policy (proposal creation)/legal/stake,168978875,446628,5969
+Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/stake,168978875,446628,5969
+Agora/Proposal/policy (proposal creation)/illegal/use other's stake/proposal,33965644,101486,1940
+Agora/Proposal/policy (proposal creation)/illegal/use other's stake/governor,369498544,984529,9887
+Agora/Proposal/policy (proposal creation)/illegal/altered stake/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/proposal,33965644,101486,1979
+Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/stake,174412535,461278,5977
+Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/proposal,33965644,101486,1991
+Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/stake,181677311,482844,5999
+Agora/Proposal/policy (proposal creation)/illegal/loose time range/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/loose time range/stake,168978875,446628,5969
+Agora/Proposal/policy (proposal creation)/illegal/open time range/proposal,33965644,101486,1967
+Agora/Proposal/policy (proposal creation)/illegal/open time range/stake,168978875,446628,5965
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/stake,168978875,446628,5969
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/stake,168978875,446628,5969
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/proposal,33965644,101486,1971
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/stake,168978875,446628,5969
+Agora/Proposal/validator/cosignature/legal/with 1 cosigners/proposal,278329834,780402,9534
+Agora/Proposal/validator/cosignature/legal/with 1 cosigners/stake,132939473,344002,5780
+Agora/Proposal/validator/cosignature/legal/with 5 cosigners/proposal,733369909,2047977,12188
+Agora/Proposal/validator/cosignature/legal/with 5 cosigners/stake,584246489,1537942,8314
+Agora/Proposal/validator/cosignature/legal/with 10 cosigners/proposal,1453961927,4008580,15507
+Agora/Proposal/validator/cosignature/legal/with 10 cosigners/stake,1244034344,3305773,11482
+Agora/Proposal/validator/cosignature/illegal/duplicate cosigners/stake,132939473,344002,5780
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: VotingReady/stake,132939473,344002,5780
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Locked/stake,132939473,344002,5780
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Finished/stake,132939473,344002,5780
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: VotingReady/stake,584246489,1537942,8314
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Locked/stake,584246489,1537942,8314
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Finished/stake,584246489,1537942,8314
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: VotingReady/stake,1244034344,3305773,11482
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Locked/stake,1244034344,3305773,11482
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Finished/stake,1244034344,3305773,11482
+Agora/Proposal/validator/voting/legal/ordinary/proposal,300100170,843476,9516
+Agora/Proposal/validator/voting/legal/ordinary/stake,157219895,416300,5803
+Agora/Proposal/validator/voting/legal/delegate/proposal,301216160,847088,9579
+Agora/Proposal/validator/voting/legal/delegate/stake,161458884,426174,5897
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,293553258,818566,10029
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,144038574,373470,6116
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,339788223,934150,10038
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,6123
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,389689216,1074147,11190
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,7275
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,494243991,1258194,11233
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,3625
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,290760522,812653,10031
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,6118
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,327404759,899415,10032
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,6119
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,329666715,904223,10032
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,6119
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,144038574,373470,6116
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,6123
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,7275
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,3625
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient cosigns/stake,144038574,373470,6116
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient votes/stake,144761110,375734,6119
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/ambiguous winning effect/stake,144761110,375734,6127
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,144038574,373470,6118
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,6123
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,201040711,510637,7275
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,494243991,1258194,11233
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15875303,48540,3625
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,494243991,1258194,11234
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,3626
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/proposal,365438170,1001538,10479
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/stake,187940552,485026,6564
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,397772898,1098350,11417
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,7502
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,3852
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,389689216,1074147,11012
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,201040711,510637,7097
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/proposal,389689216,1074147,11184
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/stake,201040711,510637,7269
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/authority,15875303,48540,3619
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/proposal,389689216,1074147,11190
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/stake,201040711,510637,7275
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/authority,15875303,48540,3625
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,340836965,940834,10618
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,144038574,373470,6509
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,390766816,1066406,10627
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,6516
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,436972923,1196415,11780
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,7669
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,514789615,1314031,11627
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,4019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,338044229,934921,10620
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,6511
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,374688466,1021683,10621
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,6512
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,376950422,1026491,10621
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,6512
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,144038574,373470,6509
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,6516
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,7669
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,4019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient cosigns/stake,144038574,373470,6509
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient votes/stake,144761110,375734,6512
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/ambiguous winning effect/stake,144761110,375734,6524
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,144038574,373470,6511
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,6516
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,201040711,510637,7669
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,514789615,1314031,11627
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15875303,48540,4019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,514789615,1314031,11628
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,4020
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/proposal,412721877,1123806,11068
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/stake,187940552,485026,6957
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,445056605,1220618,12007
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,7896
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,4246
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,436972923,1196415,11601
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,201040711,510637,7490
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/proposal,436972923,1196415,11774
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/stake,201040711,510637,7663
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/authority,15875303,48540,4013
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/proposal,436972923,1196415,11780
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/stake,201040711,510637,7669
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/authority,15875303,48540,4019
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,482688086,1307638,12390
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,144038574,373470,7690
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,543702595,1463174,12399
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,7697
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,578824044,1563219,13551
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,8849
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,576426487,1481542,12807
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,5199
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,479895350,1301725,12392
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,7692
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,516539587,1388487,12393
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,7693
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,518801543,1393295,12393
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,7693
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,144038574,373470,7690
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,7697
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,8849
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,5199
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient cosigns/stake,144038574,373470,7690
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient votes/stake,144761110,375734,7693
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/ambiguous winning effect/stake,144761110,375734,7717
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,144038574,373470,7692
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,7697
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,201040711,510637,8849
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,576426487,1481542,12807
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15875303,48540,5199
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,576426487,1481542,12808
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,5200
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/proposal,554572998,1490610,12840
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/stake,187940552,485026,8138
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,586907726,1587422,13778
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,9076
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,5426
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,578824044,1563219,13373
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,201040711,510637,8671
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/proposal,578824044,1563219,13545
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/stake,201040711,510637,8843
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/authority,15875303,48540,5193
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/proposal,578824044,1563219,13551
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/stake,201040711,510637,8849
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/authority,15875303,48540,5199
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,677995493,1927471,12799
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,582713892,1530532,8765
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,362157571,996214,10395
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,6359
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,412058564,1136211,11547
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,7511
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,501431939,1278882,11470
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,3862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,313129870,874717,10388
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,6354
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,349774107,961479,10389
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,6355
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,352036063,966287,10389
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,6355
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,582713892,1530532,8765
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,6359
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,7511
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,3862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient cosigns/stake,568599606,1489522,8765
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient votes/stake,144761110,375734,6355
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/ambiguous winning effect/stake,144761110,375734,6363
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,582713892,1530532,8767
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,6359
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,201040711,510637,7511
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,501431939,1278882,11470
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15875303,48540,3862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,501431939,1278882,11471
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,3863
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/proposal,387807518,1063602,10835
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/stake,187940552,485026,6799
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,420142246,1160414,11774
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,7738
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,4089
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,412058564,1136211,11369
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,201040711,510637,7333
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/proposal,412058564,1136211,11541
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/stake,201040711,510637,7505
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/authority,15875303,48540,3856
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/proposal,412058564,1136211,11547
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/stake,201040711,510637,7511
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/authority,15875303,48540,3862
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,725279200,2049739,13390
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,582713892,1530532,9159
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,413136164,1128470,10985
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,6752
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,459342271,1258479,12138
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,7905
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,521977563,1334719,11864
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,4256
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,360413577,996985,10978
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,6747
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,397057814,1083747,10979
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,6748
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,399319770,1088555,10979
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,6748
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,582713892,1530532,9159
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,6752
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,7905
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,4256
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient cosigns/stake,568599606,1489522,9159
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient votes/stake,144761110,375734,6748
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/ambiguous winning effect/stake,144761110,375734,6760
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,582713892,1530532,9161
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,6752
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,201040711,510637,7905
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,521977563,1334719,11864
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15875303,48540,4256
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,521977563,1334719,11865
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,4257
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/proposal,435091225,1185870,11426
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/stake,187940552,485026,7193
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,467425953,1282682,12365
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,8132
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,4483
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,459342271,1258479,11959
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,201040711,510637,7726
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/proposal,459342271,1258479,12132
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/stake,201040711,510637,7899
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/authority,15875303,48540,4250
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/proposal,459342271,1258479,12138
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/stake,201040711,510637,7905
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/authority,15875303,48540,4256
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,867130321,2416543,15160
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,582713892,1530532,10339
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,566071943,1525238,12756
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,7933
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,601193392,1625283,13908
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,9085
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,583614435,1502230,13044
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,5436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,502264698,1363789,12749
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,7928
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,538908935,1450551,12750
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,7929
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,541170891,1455359,12750
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,7929
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,582713892,1530532,10339
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,7933
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,9085
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,5436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient cosigns/stake,568599606,1489522,10339
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient votes/stake,144761110,375734,7929
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/ambiguous winning effect/stake,144761110,375734,7953
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,582713892,1530532,10341
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,7933
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,201040711,510637,9085
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,583614435,1502230,13044
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15875303,48540,5436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,583614435,1502230,13045
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,5437
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/proposal,576942346,1552674,13197
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/stake,187940552,485026,8374
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,609277074,1649486,14135
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,9312
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,5663
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,601193392,1625283,13730
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,201040711,510637,8907
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/proposal,601193392,1625283,13902
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/stake,201040711,510637,9079
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/authority,15875303,48540,5430
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/proposal,601193392,1625283,13908
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/stake,201040711,510637,9085
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/authority,15875303,48540,5436
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,1245892718,3569074,16268
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,1243243041,3300429,12083
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,390119256,1073794,10847
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,6660
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,440020249,1213791,11999
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,7812
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,510416874,1304742,11771
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,4163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,341091555,952297,10840
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,6655
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,377735792,1039059,10841
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,6656
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,379997748,1043867,10841
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,6656
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,1243243041,3300429,12083
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,6660
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,7812
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,4163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient cosigns/stake,1257357327,3341439,12083
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient votes/stake,144761110,375734,6656
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/ambiguous winning effect/stake,144761110,375734,6664
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,1243243041,3300429,12085
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,6660
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,201040711,510637,7812
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,510416874,1304742,11771
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15875303,48540,4163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,510416874,1304742,11772
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,4164
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/proposal,415769203,1141182,11288
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/stake,187940552,485026,7101
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,448103931,1237994,12226
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,8039
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,4390
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,440020249,1213791,11821
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,201040711,510637,7634
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/proposal,440020249,1213791,11993
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/stake,201040711,510637,7806
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/authority,15875303,48540,4157
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/proposal,440020249,1213791,11999
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/stake,201040711,510637,7812
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/authority,15875303,48540,4163
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,1293176425,3691342,16858
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,1243243041,3300429,12477
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,441097849,1206050,11436
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,7053
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,487303956,1336059,12589
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,8206
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,530962498,1360579,12165
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,4557
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,388375262,1074565,11429
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,7048
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,425019499,1161327,11430
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,7049
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,427281455,1166135,11430
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,7049
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,1243243041,3300429,12477
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,7053
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,8206
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,4557
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient cosigns/stake,1257357327,3341439,12477
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient votes/stake,144761110,375734,7049
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/ambiguous winning effect/stake,144761110,375734,7061
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,1243243041,3300429,12479
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,7053
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,201040711,510637,8206
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,530962498,1360579,12165
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15875303,48540,4557
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,530962498,1360579,12166
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,4558
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/proposal,463052910,1263450,11877
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/stake,187940552,485026,7494
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,495387638,1360262,12816
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,8433
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,4784
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,487303956,1336059,12410
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,201040711,510637,8027
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/proposal,487303956,1336059,12583
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/stake,201040711,510637,8200
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/authority,15875303,48540,4551
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/proposal,487303956,1336059,12589
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/stake,201040711,510637,8206
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/authority,15875303,48540,4557
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,1435027546,4058146,18629
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,1243243041,3300429,13657
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,594033628,1602818,13208
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,144761110,375734,8234
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,629155077,1702863,14361
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,201040711,510637,9387
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,592599370,1528090,13346
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15875303,48540,5738
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,530226383,1441369,13201
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,144761110,375734,8229
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,566870620,1528131,13202
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,144761110,375734,8230
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,569132576,1532939,13202
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,144761110,375734,8230
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,1243243041,3300429,13657
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,144761110,375734,8234
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,201040711,510637,9387
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15875303,48540,5738
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient cosigns/stake,1257357327,3341439,13657
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient votes/stake,144761110,375734,8230
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/ambiguous winning effect/stake,144761110,375734,8254
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,1243243041,3300429,13659
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,144761110,375734,8234
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,201040711,510637,9387
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,592599370,1528090,13346
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15875303,48540,5738
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,592599370,1528090,13347
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15875303,48540,5739
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/proposal,604904031,1630254,13649
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/stake,187940552,485026,8675
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,637238759,1727066,14587
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,204588820,517864,9613
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17699300,53602,5964
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,629155077,1702863,14182
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,201040711,510637,9208
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/proposal,629155077,1702863,14355
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/stake,201040711,510637,9381
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/authority,15875303,48540,5731
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/proposal,629155077,1702863,14361
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/stake,201040711,510637,9387
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/authority,15875303,48540,5738
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/stake,140863709,370195,5783
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/proposal,282615841,794299,9497
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/stake,147212927,388303,5799
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/proposal,300115413,843740,9508
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/stake,139825432,367397,5781
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/proposal,256687085,727957,9494
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/stake,143981681,379249,5797
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/proposal,264924554,752465,9506
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/stake,140863709,370195,5787
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/proposal,252614193,719732,9501
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/stake,140863709,370195,5787
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/proposal,253179682,720934,9501
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/stake,147212927,388303,5803
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/proposal,270679254,770375,9512
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/stake,297243845,781199,7876
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/proposal,425257089,1206963,11566
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/stake,328989935,871739,7952
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/proposal,494812989,1407716,11617
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/stake,292052460,767209,7865
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/proposal,364767897,1045813,11558
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/stake,312833705,826469,7946
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/proposal,402960090,1157169,11611
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/stake,297243845,781199,7896
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/proposal,364848113,1048780,11586
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/stake,297243845,781199,7896
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/proposal,365413602,1049982,11586
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/stake,328989935,871739,7972
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/proposal,434969502,1250735,11637
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/stake,492719015,1294954,10491
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/proposal,603558649,1722793,14151
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/stake,556211195,1476034,10642
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/proposal,738184959,2112686,14252
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/stake,482336245,1266974,10471
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/proposal,499868912,1443133,14139
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/stake,523898735,1385494,10631
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/proposal,575504510,1663049,14241
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/stake,492719015,1294954,10531
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/proposal,505140513,1460090,14191
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/stake,492719015,1294954,10531
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/proposal,505706002,1461292,14191
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/stake,556211195,1476034,10682
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/proposal,640332312,1851185,14292
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/stake,1743760103,4582986,27321
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/proposal,1744688633,5024105,30770
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/stake,2010427259,5343522,28008
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/proposal,2295765567,6624494,31228
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/stake,1700152469,4465470,27236
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/proposal,1364515408,3985981,30725
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/stake,1874714927,4963254,27947
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/proposal,1679788798,4900681,31167
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/stake,1743760103,4582986,27489
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/proposal,1403011873,4092474,30938
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/stake,1743760103,4582986,27489
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/proposal,1403577362,4093676,30938
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/stake,2010427259,5343522,28177
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/proposal,1954654296,5694065,31397
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Draft/stake",140863709,370195,5783
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Locked/stake",140863709,370195,5783
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Finished/stake",140863709,370195,5783
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Draft/stake",135454846,355547,5785
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Locked/stake",135454846,355547,5785
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Finished/stake",135454846,355547,5785
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Draft/stake",147212927,388303,5799
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Locked/stake",147212927,388303,5799
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Finished/stake",147212927,388303,5799
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",129105628,337439,5765
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",129105628,337439,5765
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,129105628,337439,5765
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Draft/stake,139825432,367397,5781
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: VotingReady/stake,139825432,367397,5781
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Locked/stake,139825432,367397,5781
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/creator: retract votes/stake,139825432,367397,5779
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Draft/stake",297243845,781199,7876
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Locked/stake",297243845,781199,7876
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Finished/stake",297243845,781199,7876
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Draft/stake",285403194,749767,7882
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Locked/stake",285403194,749767,7882
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Finished/stake",285403194,749767,7882
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Draft/stake",328989935,871739,7952
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Locked/stake",328989935,871739,7952
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Finished/stake",328989935,871739,7952
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",253657104,659227,7793
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",253657104,659227,7793
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,253657104,659227,7793
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Draft/stake,292052460,767209,7865
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: VotingReady/stake,292052460,767209,7865
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Locked/stake,292052460,767209,7865
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/creator: retract votes/stake,292052460,767209,7855
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Draft/stake",492719015,1294954,10491
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Locked/stake",492719015,1294954,10491
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Finished/stake",492719015,1294954,10491
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Draft/stake",472838629,1242542,10502
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Locked/stake",472838629,1242542,10502
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Finished/stake",472838629,1242542,10502
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Draft/stake",556211195,1476034,10642
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Locked/stake",556211195,1476034,10642
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Finished/stake",556211195,1476034,10642
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",409346449,1061462,10328
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",409346449,1061462,10328
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,409346449,1061462,10328
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Draft/stake,482336245,1266974,10471
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: VotingReady/stake,482336245,1266974,10471
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Locked/stake,482336245,1266974,10471
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/creator: retract votes/stake,482336245,1266974,10450
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Draft/stake",1743760103,4582986,27321
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Locked/stake",1743760103,4582986,27321
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Finished/stake",1743760103,4582986,27321
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Draft/stake",1672425413,4396302,27382
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Locked/stake",1672425413,4396302,27382
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Finished/stake",1672425413,4396302,27382
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Draft/stake",2010427259,5343522,28008
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Locked/stake",2010427259,5343522,28008
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Finished/stake",2010427259,5343522,28008
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",1405758257,3635766,26608
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",1405758257,3635766,26608
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,1405758257,3635766,26608
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Draft/stake,1700152469,4465470,27236
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: VotingReady/stake,1700152469,4465470,27236
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Locked/stake,1700152469,4465470,27236
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/creator: retract votes/stake,1700152469,4465470,27152
 Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,19822997,52452,427
 Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32009395,84810,527
-Agora/Treasury/Validator/Positive/Allows for effect changes,30529414,78579,983
+Agora/Treasury/Validator/Positive/Allows for effect changes,31553082,81982,1423
 Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,19822997,52452,427
 Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32009395,84810,527
-Agora/Governor/policy/totally legal,67334379,187470,1867
-Agora/Governor/validator/mutate/legal,115397394,308142,6308
+Agora/Governor/policy/totally legal,70301827,197578,2576
+Agora/Governor/validator/mutate/legal,119848510,323653,9297

--- a/bench.csv
+++ b/bench.csv
@@ -1,582 +1,582 @@
 name,cpu,mem,size
-Agora/Effects/Treasury Withdrawal Effect/effect/Simple,333137234,829671,3674
-Agora/Effects/Treasury Withdrawal Effect/effect/Simple with multiple treasuries ,492197164,1196783,3986
-Agora/Effects/Treasury Withdrawal Effect/effect/Mixed Assets,455817227,1103968,3859
-Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/governor validator should pass,93089688,256879,8317
-Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/effect validator should pass,112671240,312571,3751
-Agora/Stake/policy/stakeCreation,51392011,150393,2536
-Agora/Stake/validator/stakeDepositWithdraw deposit,186703362,508556,5339
-Agora/Stake/validator/stakeDepositWithdraw withdraw,186703362,508556,5327
-Agora/Stake/validator/set delegate/override existing delegate,113710649,295990,5391
-Agora/Stake/validator/set delegate/remove existing delegate,110917776,287315,5328
-Agora/Stake/validator/set delegate/set delegate to something,110293742,288964,5328
-Agora/Proposal/policy (proposal creation)/legal/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/legal/governor,325452519,864627,8802
-Agora/Proposal/policy (proposal creation)/legal/stake,155649225,408558,5993
-Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/stake,155649225,408558,5993
-Agora/Proposal/policy (proposal creation)/illegal/use other's stake/proposal,33689644,100286,1980
-Agora/Proposal/policy (proposal creation)/illegal/use other's stake/governor,325452519,864627,8771
-Agora/Proposal/policy (proposal creation)/illegal/altered stake/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/proposal,33689644,100286,2019
-Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/stake,161082885,423208,6001
-Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/proposal,33689644,100286,2031
-Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/stake,162111717,426666,6023
-Agora/Proposal/policy (proposal creation)/illegal/loose time range/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/loose time range/stake,155649225,408558,5993
-Agora/Proposal/policy (proposal creation)/illegal/open time range/proposal,33689644,100286,2007
-Agora/Proposal/policy (proposal creation)/illegal/open time range/stake,155649225,408558,5989
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/stake,155649225,408558,5993
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/stake,155649225,408558,5993
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/proposal,33689644,100286,2011
-Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/stake,155649225,408558,5993
-Agora/Proposal/validator/cosignature/legal/with 1 cosigners/proposal,236423139,660573,8414
-Agora/Proposal/validator/cosignature/legal/with 1 cosigners/stake,124318976,323958,5801
-Agora/Proposal/validator/cosignature/legal/with 5 cosigners/proposal,665645490,1853924,11068
-Agora/Proposal/validator/cosignature/legal/with 5 cosigners/stake,540258584,1423290,8335
-Agora/Proposal/validator/cosignature/legal/with 10 cosigners/proposal,1353965353,3721747,14387
-Agora/Proposal/validator/cosignature/legal/with 10 cosigners/stake,1155837179,3072861,11503
-Agora/Proposal/validator/cosignature/illegal/duplicate cosigners/stake,124318976,323958,5801
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: VotingReady/stake,124318976,323958,5801
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Locked/stake,124318976,323958,5801
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Finished/stake,124318976,323958,5801
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: VotingReady/stake,540258584,1423290,8335
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Locked/stake,540258584,1423290,8335
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Finished/stake,540258584,1423290,8335
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: VotingReady/stake,1155837179,3072861,11503
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Locked/stake,1155837179,3072861,11503
-Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Finished/stake,1155837179,3072861,11503
-Agora/Proposal/validator/voting/legal/ordinary/proposal,254761960,715291,8396
-Agora/Proposal/validator/voting/legal/ordinary/stake,142726431,376372,5827
-Agora/Proposal/validator/voting/legal/delegate/proposal,254862648,715291,8459
-Agora/Proposal/validator/voting/legal/delegate/stake,146143338,383398,5921
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,249151017,693538,8909
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,134728077,350426,6137
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,293313747,804549,8918
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,6144
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,340814784,939138,10070
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,7296
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,467588561,1169520,10118
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,3659
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,244096325,682817,8911
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,6139
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,279799305,767410,8912
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,6140
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,280930283,769814,8912
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,6140
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,134728077,350426,6137
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,6144
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,7296
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,3659
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient cosigns/stake,134728077,350426,6137
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient votes/stake,135450613,352690,6140
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/ambiguous winning effect/stake,135450613,352690,6148
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,134728077,350426,6139
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,6144
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190212214,480993,7296
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,467588561,1169520,10118
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15806303,48240,3659
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,467588561,1169520,10119
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,3660
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/proposal,316563738,866529,9359
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/stake,177112055,455382,6585
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,348898466,963341,10297
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,7523
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,3886
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,340814784,939138,9892
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190212214,480993,7118
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/proposal,340814784,939138,10064
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/stake,190212214,480993,7290
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/authority,15806303,48240,3653
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/proposal,340814784,939138,10070
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/stake,190212214,480993,7296
-Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/authority,15806303,48240,3659
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,294552365,811630,9498
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,134728077,350426,6530
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,342409981,932629,9507
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,6537
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,386216132,1057230,10660
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,7690
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,487506732,1223965,10512
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,4053
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,289497673,800909,9500
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,6532
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,325200653,885502,9501
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,6533
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,326331631,887906,9501
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,6533
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,134728077,350426,6530
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,6537
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,7690
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,4053
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient cosigns/stake,134728077,350426,6530
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient votes/stake,135450613,352690,6533
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/ambiguous winning effect/stake,135450613,352690,6545
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,134728077,350426,6532
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,6537
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190212214,480993,7690
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,487506732,1223965,10512
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15806303,48240,4053
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,487506732,1223965,10513
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,4054
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/proposal,361965086,984621,9948
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/stake,177112055,455382,6978
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,394299814,1081433,10887
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,7917
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,4280
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,386216132,1057230,10481
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190212214,480993,7511
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/proposal,386216132,1057230,10654
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/stake,190212214,480993,7684
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/authority,15806303,48240,4047
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/proposal,386216132,1057230,10660
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/stake,190212214,480993,7690
-Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/authority,15806303,48240,4053
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,430756409,1165906,11270
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,134728077,350426,7711
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,489698683,1316869,11279
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,7718
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,522420176,1411506,12431
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,8870
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,547261245,1387300,11692
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,5233
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,425701717,1155185,11272
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,7713
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,461404697,1239778,11273
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,7714
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,462535675,1242182,11273
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,7714
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,134728077,350426,7711
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,7718
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,8870
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,5233
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient cosigns/stake,134728077,350426,7711
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient votes/stake,135450613,352690,7714
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/ambiguous winning effect/stake,135450613,352690,7738
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,134728077,350426,7713
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,7718
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190212214,480993,8870
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,547261245,1387300,11692
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15806303,48240,5233
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,547261245,1387300,11693
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,5234
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/proposal,498169130,1338897,11720
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/stake,177112055,455382,8159
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,530503858,1435709,12658
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,9097
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,5460
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,522420176,1411506,12253
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190212214,480993,8692
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/proposal,522420176,1411506,12425
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/stake,190212214,480993,8864
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/authority,15806303,48240,5227
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/proposal,522420176,1411506,12431
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/stake,190212214,480993,8870
-Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/authority,15806303,48240,5233
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,607775528,1728219,11679
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,538035987,1412880,8786
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,315683095,866613,9275
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,6380
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,363184132,1001202,10427
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,7532
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,474776509,1190208,10355
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,3896
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,266465673,744881,9268
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,6375
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,302168653,829474,9269
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,6376
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,303299631,831878,9269
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,6376
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,538035987,1412880,8786
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,6380
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,7532
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,3896
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient cosigns/stake,523921701,1371870,8786
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient votes/stake,135450613,352690,6376
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/ambiguous winning effect/stake,135450613,352690,6384
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,538035987,1412880,8788
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,6380
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190212214,480993,7532
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,474776509,1190208,10355
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15806303,48240,3896
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,474776509,1190208,10356
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,3897
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/proposal,338933086,928593,9715
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/stake,177112055,455382,6820
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,371267814,1025405,10654
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,7759
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,4123
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,363184132,1001202,10249
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190212214,480993,7354
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/proposal,363184132,1001202,10421
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/stake,190212214,480993,7526
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/authority,15806303,48240,3890
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/proposal,363184132,1001202,10427
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/stake,190212214,480993,7532
-Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/authority,15806303,48240,3896
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,653176876,1846311,12270
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,538035987,1412880,9180
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,364779329,994693,9865
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,6773
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,408585480,1119294,11018
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,7926
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,494694680,1244653,10749
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,4290
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,311867021,862973,9858
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,6768
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,347570001,947566,9859
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,6769
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,348700979,949970,9859
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,6769
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,538035987,1412880,9180
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,6773
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,7926
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,4290
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient cosigns/stake,523921701,1371870,9180
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient votes/stake,135450613,352690,6769
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/ambiguous winning effect/stake,135450613,352690,6781
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,538035987,1412880,9182
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,6773
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190212214,480993,7926
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,494694680,1244653,10749
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15806303,48240,4290
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,494694680,1244653,10750
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,4291
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/proposal,384334434,1046685,10306
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/stake,177112055,455382,7214
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,416669162,1143497,11245
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,8153
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,4517
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,408585480,1119294,10839
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190212214,480993,7747
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/proposal,408585480,1119294,11012
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/stake,190212214,480993,7920
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/authority,15806303,48240,4284
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/proposal,408585480,1119294,11018
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/stake,190212214,480993,7926
-Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/authority,15806303,48240,4290
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,789380920,2200587,14040
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,538035987,1412880,10360
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,512068031,1378933,11636
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,7954
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,544789524,1473570,12788
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,9106
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,554449193,1407988,11929
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,5470
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,448071065,1217249,11629
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,7949
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,483774045,1301842,11630
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,7950
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,484905023,1304246,11630
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,7950
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,538035987,1412880,10360
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,7954
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,9106
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,5470
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient cosigns/stake,523921701,1371870,10360
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient votes/stake,135450613,352690,7950
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/ambiguous winning effect/stake,135450613,352690,7974
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,538035987,1412880,10362
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,7954
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190212214,480993,9106
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,554449193,1407988,11929
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15806303,48240,5470
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,554449193,1407988,11930
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,5471
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/proposal,520538478,1400961,12077
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/stake,177112055,455382,8395
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,552873206,1497773,13015
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,9333
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,5697
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,544789524,1473570,12610
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190212214,480993,8928
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/proposal,544789524,1473570,12782
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/stake,190212214,480993,9100
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/authority,15806303,48240,5464
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/proposal,544789524,1473570,12788
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/stake,190212214,480993,9106
-Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/authority,15806303,48240,5470
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,1143400598,3277042,15148
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,1154355876,3064517,12104
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,343644780,944193,9727
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,6681
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,391145817,1078782,10879
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,7833
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,483761444,1216068,10656
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,4197
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,294427358,822461,9720
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,6676
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,330130338,907054,9721
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,6677
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,331261316,909458,9721
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,6677
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,1154355876,3064517,12104
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,6681
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,7833
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,4197
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient cosigns/stake,1168470162,3105527,12104
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient votes/stake,135450613,352690,6677
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/ambiguous winning effect/stake,135450613,352690,6685
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,1154355876,3064517,12106
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,6681
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190212214,480993,7833
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,483761444,1216068,10656
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15806303,48240,4197
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,483761444,1216068,10657
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,4198
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/proposal,366894771,1006173,10168
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/stake,177112055,455382,7122
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,399229499,1102985,11106
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,8060
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,4424
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,391145817,1078782,10701
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190212214,480993,7655
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/proposal,391145817,1078782,10873
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/stake,190212214,480993,7827
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/authority,15806303,48240,4191
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/proposal,391145817,1078782,10879
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/stake,190212214,480993,7833
-Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/authority,15806303,48240,4197
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,1188801946,3395134,15738
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,1154355876,3064517,12498
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,392741014,1072273,10316
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,7074
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,436547165,1196874,11469
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,8227
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,503679615,1270513,11050
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,4591
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,339828706,940553,10309
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,7069
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,375531686,1025146,10310
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,7070
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,376662664,1027550,10310
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,7070
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,1154355876,3064517,12498
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,7074
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,8227
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,4591
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient cosigns/stake,1168470162,3105527,12498
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient votes/stake,135450613,352690,7070
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/ambiguous winning effect/stake,135450613,352690,7082
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,1154355876,3064517,12500
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,7074
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190212214,480993,8227
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,503679615,1270513,11050
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15806303,48240,4591
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,503679615,1270513,11051
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,4592
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/proposal,412296119,1124265,10757
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/stake,177112055,455382,7515
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,444630847,1221077,11696
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,8454
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,4818
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,436547165,1196874,11290
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190212214,480993,8048
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/proposal,436547165,1196874,11463
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/stake,190212214,480993,8221
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/authority,15806303,48240,4585
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/proposal,436547165,1196874,11469
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/stake,190212214,480993,8227
-Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/authority,15806303,48240,4591
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,1325005990,3749410,17509
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,1154355876,3064517,13678
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,540029716,1456513,12088
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,135450613,352690,8255
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,572751209,1551150,13241
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190212214,480993,9408
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,563434128,1433848,12231
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15806303,48240,5772
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,476032750,1294829,12081
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,135450613,352690,8250
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,511735730,1379422,12082
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,135450613,352690,8251
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,512866708,1381826,12082
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,135450613,352690,8251
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,1154355876,3064517,13678
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,135450613,352690,8255
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190212214,480993,9408
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15806303,48240,5772
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient cosigns/stake,1168470162,3105527,13678
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient votes/stake,135450613,352690,8251
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/ambiguous winning effect/stake,135450613,352690,8275
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,1154355876,3064517,13680
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,135450613,352690,8255
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190212214,480993,9408
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,563434128,1433848,12231
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15806303,48240,5772
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,563434128,1433848,12232
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15806303,48240,5773
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/proposal,548500163,1478541,12529
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/stake,177112055,455382,8696
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,580834891,1575353,13467
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,193760323,488220,9634
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17630300,53302,5998
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,572751209,1551150,13062
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190212214,480993,9229
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/proposal,572751209,1551150,13235
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/stake,190212214,480993,9402
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/authority,15806303,48240,5765
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/proposal,572751209,1551150,13241
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/stake,190212214,480993,9408
-Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/authority,15806303,48240,5772
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/stake,131657472,344523,5807
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/proposal,237178475,667478,8377
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/stake,134888718,353577,5823
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/proposal,250650682,707420,8388
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/stake,131657472,344523,5805
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/proposal,204970610,587333,8374
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/stake,131657472,344523,5821
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/proposal,213404867,612237,8386
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/stake,131657472,344523,5811
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/proposal,206286762,591217,8381
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/stake,131657472,344523,5811
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/proposal,206286762,591217,8381
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/stake,134888718,353577,5827
-Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/proposal,220290545,632551,8392
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/stake,282446716,721159,7900
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/proposal,379819723,1080142,10446
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/stake,298602946,766429,7976
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/proposal,445348258,1271396,10497
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/stake,282446716,721159,7889
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/proposal,313051422,905189,10438
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/stake,282446716,721159,7970
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/proposal,351440403,1016941,10491
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/stake,282446716,721159,7920
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/proposal,318520682,920265,10466
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/stake,282446716,721159,7920
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/proposal,318520682,920265,10466
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/stake,298602946,766429,7996
-Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/proposal,384580793,1112911,10517
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/stake,470933271,1191954,10515
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/proposal,558121283,1595972,13031
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/stake,503245731,1282494,10666
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/proposal,688720228,1976366,13132
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/stake,470933271,1191954,10495
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/proposal,448152437,1302509,13019
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/stake,470933271,1191954,10655
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/proposal,523984823,1522821,13121
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/stake,470933271,1191954,10555
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/proposal,458813082,1331575,13071
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/stake,470933271,1191954,10555
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/proposal,458813082,1331575,13071
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/stake,503245731,1282494,10706
-Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/proposal,589943603,1713361,13172
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/stake,1677247223,4205042,27345
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/proposal,1699251267,4897284,29650
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/stake,1812959555,4585310,28032
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/proposal,2246300836,6488174,30108
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/stake,1677247223,4205042,27260
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/proposal,1312798933,3845357,29605
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/stake,1677247223,4205042,27971
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/proposal,1628269111,4760453,30047
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/stake,1677247223,4205042,27513
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/proposal,1356684442,3963959,29818
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/stake,1677247223,4205042,27513
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/proposal,1356684442,3963959,29818
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/stake,1812959555,4585310,28201
-Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/proposal,1904265587,5556241,30277
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Draft/stake",131657472,344523,5807
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Locked/stake",131657472,344523,5807
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Finished/stake",131657472,344523,5807
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Draft/stake",127286886,332673,5809
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Locked/stake",127286886,332673,5809
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Finished/stake",127286886,332673,5809
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Draft/stake",134888718,353577,5823
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Locked/stake",134888718,353577,5823
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Finished/stake",134888718,353577,5823
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",124055640,323619,5789
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",124055640,323619,5789
-"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,124055640,323619,5789
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Draft/stake,131657472,344523,5805
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: VotingReady/stake,131657472,344523,5805
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Locked/stake,131657472,344523,5805
-Agora/Proposal/validator/unlocking/illegal/with 1 proposals/creator: retract votes/stake,131657472,344523,5803
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Draft/stake",282446716,721159,7900
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Locked/stake",282446716,721159,7900
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Finished/stake",282446716,721159,7900
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Draft/stake",275797450,703717,7906
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Locked/stake",275797450,703717,7906
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Finished/stake",275797450,703717,7906
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Draft/stake",298602946,766429,7976
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Locked/stake",298602946,766429,7976
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Finished/stake",298602946,766429,7976
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",259641220,658447,7817
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",259641220,658447,7817
-"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,259641220,658447,7817
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Draft/stake,282446716,721159,7889
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: VotingReady/stake,282446716,721159,7889
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Locked/stake,282446716,721159,7889
-Agora/Proposal/validator/unlocking/illegal/with 5 proposals/creator: retract votes/stake,282446716,721159,7879
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Draft/stake",470933271,1191954,10515
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Locked/stake",470933271,1191954,10515
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Finished/stake",470933271,1191954,10515
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Draft/stake",461435655,1167522,10526
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Locked/stake",461435655,1167522,10526
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Finished/stake",461435655,1167522,10526
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Draft/stake",503245731,1282494,10666
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Locked/stake",503245731,1282494,10666
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Finished/stake",503245731,1282494,10666
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",429123195,1076982,10352
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",429123195,1076982,10352
-"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,429123195,1076982,10352
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Draft/stake,470933271,1191954,10495
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: VotingReady/stake,470933271,1191954,10495
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Locked/stake,470933271,1191954,10495
-Agora/Proposal/validator/unlocking/illegal/with 10 proposals/creator: retract votes/stake,470933271,1191954,10474
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Draft/stake",1677247223,4205042,27345
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Locked/stake",1677247223,4205042,27345
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Finished/stake",1677247223,4205042,27345
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Draft/stake",1649520167,4135874,27406
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Locked/stake",1649520167,4135874,27406
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Finished/stake",1649520167,4135874,27406
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Draft/stake",1812959555,4585310,28032
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Locked/stake",1812959555,4585310,28032
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Finished/stake",1812959555,4585310,28032
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",1513807835,3755606,26632
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",1513807835,3755606,26632
-"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,1513807835,3755606,26632
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Draft/stake,1677247223,4205042,27260
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: VotingReady/stake,1677247223,4205042,27260
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Locked/stake,1677247223,4205042,27260
-Agora/Proposal/validator/unlocking/illegal/with 42 proposals/creator: retract votes/stake,1677247223,4205042,27176
-Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,20570665,54655,725
-Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32757063,87013,825
-Agora/Treasury/Validator/Positive/Allows for effect changes,31277082,80782,1450
-Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,20570665,54655,725
-Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32757063,87013,825
-Agora/Governor/policy/totally legal,60002734,167736,2268
-Agora/Governor/validator/mutate/legal,100216324,268169,8181
+Agora/Effects/Treasury Withdrawal Effect/effect/Simple,12736207,40996,2908
+Agora/Effects/Treasury Withdrawal Effect/effect/Simple with multiple treasuries ,12736207,40996,3220
+Agora/Effects/Treasury Withdrawal Effect/effect/Mixed Assets,12736207,40996,3093
+Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/governor validator should pass,108270758,296852,6444
+Agora/Effects/Governor Mutation Effect/validator/valid new governor datum/effect validator should pass,7973222,20696,3222
+Agora/Stake/policy/stakeCreation,53357294,155623,2050
+Agora/Stake/validator/stakeDepositWithdraw deposit,187795456,518604,3825
+Agora/Stake/validator/stakeDepositWithdraw withdraw,187795456,518604,3813
+Agora/Stake/validator/set delegate/override existing delegate,100639801,266338,3877
+Agora/Stake/validator/set delegate/remove existing delegate,98230359,259005,3814
+Agora/Stake/validator/set delegate/set delegate to something,100539113,266338,3814
+Agora/Proposal/policy (proposal creation)/legal/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/legal/governor,354848880,943893,6928
+Agora/Proposal/policy (proposal creation)/legal/stake,153933633,408520,4479
+Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/invalid next proposal id/stake,153933633,408520,4479
+Agora/Proposal/policy (proposal creation)/illegal/use other's stake/proposal,33873644,101086,1811
+Agora/Proposal/policy (proposal creation)/illegal/use other's stake/governor,354848880,943893,6897
+Agora/Proposal/policy (proposal creation)/illegal/altered stake/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/proposal,33873644,101086,1850
+Agora/Proposal/policy (proposal creation)/illegal/invalid stake locks/stake,159367293,423170,4487
+Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/proposal,33873644,101086,1862
+Agora/Proposal/policy (proposal creation)/illegal/has reached maximum proposals limit/stake,160396125,426628,4509
+Agora/Proposal/policy (proposal creation)/illegal/loose time range/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/loose time range/stake,153933633,408520,4479
+Agora/Proposal/policy (proposal creation)/illegal/open time range/proposal,33873644,101086,1838
+Agora/Proposal/policy (proposal creation)/illegal/open time range/stake,153933633,408520,4475
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/VotingReady/stake,153933633,408520,4479
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Locked/stake,153933633,408520,4479
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/proposal,33873644,101086,1842
+Agora/Proposal/policy (proposal creation)/illegal/invalid proposal status/Finished/stake,153933633,408520,4479
+Agora/Proposal/validator/cosignature/legal/with 1 cosigners/proposal,270612694,756318,6994
+Agora/Proposal/validator/cosignature/legal/with 1 cosigners/stake,120950501,317982,4287
+Agora/Proposal/validator/cosignature/legal/with 5 cosigners/proposal,711284625,1983397,9648
+Agora/Proposal/validator/cosignature/legal/with 5 cosigners/stake,552610861,1480482,6821
+Agora/Proposal/validator/cosignature/legal/with 10 cosigners/proposal,1413916463,3893380,12967
+Agora/Proposal/validator/cosignature/legal/with 10 cosigners/stake,1187840396,3209013,9989
+Agora/Proposal/validator/cosignature/illegal/duplicate cosigners/stake,120950501,317982,4287
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: VotingReady/stake,120950501,317982,4287
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Locked/stake,120950501,317982,4287
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 1 cosigners/status: Finished/stake,120950501,317982,4287
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: VotingReady/stake,552610861,1480482,6821
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Locked/stake,552610861,1480482,6821
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 5 cosigners/status: Finished/stake,552610861,1480482,6821
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: VotingReady/stake,1187840396,3209013,9989
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Locked/stake,1187840396,3209013,9989
+Agora/Proposal/validator/cosignature/illegal/proposal status not Draft/with 10 cosigners/status: Finished/stake,1187840396,3209013,9989
+Agora/Proposal/validator/voting/legal/ordinary/proposal,292107030,818192,6976
+Agora/Proposal/validator/voting/legal/ordinary/stake,138776145,368604,4313
+Agora/Proposal/validator/voting/legal/delegate/proposal,293223020,821804,7039
+Agora/Proposal/validator/voting/legal/delegate/stake,135207796,352770,4407
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,278165358,776398,7489
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,4623
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,323181211,887380,7498
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,4630
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,373749316,1029579,8650
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,5782
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,495323391,1250397,8245
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3342
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,275372622,770485,7491
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,4625
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,311464859,854847,7492
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,4626
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,313726815,859655,7492
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,4626
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,4623
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,4630
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,5782
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3342
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient cosigns/stake,132049602,347450,4623
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,4626
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,4634
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,132049602,347450,4625
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,4630
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,5782
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,495323391,1250397,8245
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3342
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,495323391,1250397,8246
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3343
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/proposal,349498270,956970,7939
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5071
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,381832998,1053782,8877
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6009
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3569
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,373749316,1029579,8472
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5604
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/proposal,373749316,1029579,8644
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,5776
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3336
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/proposal,373749316,1029579,8650
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,5782
+Agora/Proposal/validator/advancing/with 1 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3342
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,318054305,881782,8078
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,5016
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,366765044,1002752,8087
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5023
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,413638263,1134963,9240
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6176
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,513404095,1300606,8639
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3736
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,315261569,875869,8080
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5018
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,351353806,960231,8081
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,353615762,965039,8081
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,5016
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5023
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6176
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3736
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient cosigns/stake,132049602,347450,5016
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5019
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5031
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,132049602,347450,5018
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5023
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6176
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,513404095,1300606,8639
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3736
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,513404095,1300606,8640
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3737
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/proposal,389387217,1062354,8528
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,5464
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,421721945,1159166,9467
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6403
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3963
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,413638263,1134963,9061
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5997
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/proposal,413638263,1134963,9234
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6170
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,3730
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/proposal,413638263,1134963,9240
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6176
+Agora/Proposal/validator/advancing/with 1 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,3736
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,437721146,1197934,9850
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,132049602,347450,6197
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,497516543,1348868,9859
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6204
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,533305104,1451115,11011
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7356
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,567646207,1451233,9819
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,4916
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,434928410,1192021,9852
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6199
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,471020647,1276383,9853
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6200
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,473282603,1281191,9853
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6200
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132049602,347450,6197
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6204
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7356
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,4916
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient cosigns/stake,132049602,347450,6197
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6200
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6224
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,132049602,347450,6199
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6204
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7356
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,567646207,1451233,9819
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,4916
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,567646207,1451233,9820
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,4917
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/proposal,509054058,1378506,10300
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,6645
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,541388786,1475318,11238
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,7583
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5143
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,533305104,1451115,10833
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7178
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/proposal,533305104,1451115,11005
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7350
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,4910
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/proposal,533305104,1451115,11011
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7356
+Agora/Proposal/validator/advancing/with 1 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,4916
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,648239449,1844807,10259
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,7272
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,345550559,949444,7855
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,4866
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,396118664,1091643,9007
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6018
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,502511339,1271085,8482
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3579
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,297741970,832549,7848
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,4861
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,333834207,916911,7849
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,4862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,336096163,921719,7849
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,4862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,7272
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,4866
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6018
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3579
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient cosigns/stake,536963978,1432062,7272
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,4862
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,4870
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,7274
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,4866
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6018
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,502511339,1271085,8482
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3579
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,502511339,1271085,8483
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3580
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/proposal,371867618,1019034,8295
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5306
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,404202346,1115846,9234
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6245
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,3806
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,396118664,1091643,8829
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,5840
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/proposal,396118664,1091643,9001
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,6012
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3573
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/proposal,396118664,1091643,9007
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,6018
+Agora/Proposal/validator/advancing/with 5 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3579
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,688128396,1950191,10850
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,7666
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,389134392,1064816,8445
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5259
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,436007611,1197027,9598
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6412
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,520592043,1321294,8876
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3973
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,337630917,937933,8438
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5254
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,373723154,1022295,8439
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5255
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,375985110,1027103,8439
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5255
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,7666
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5259
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6412
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3973
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient cosigns/stake,536963978,1432062,7666
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5255
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5267
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,7668
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5259
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6412
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,520592043,1321294,8876
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3973
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,520592043,1321294,8877
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3974
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/proposal,411756565,1124418,8886
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,5700
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,444091293,1221230,9825
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6639
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4200
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,436007611,1197027,9419
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6233
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/proposal,436007611,1197027,9592
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6406
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,3967
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/proposal,436007611,1197027,9598
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6412
+Agora/Proposal/validator/advancing/with 5 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,3973
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,807795237,2266343,12620
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,551078264,1473072,8846
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,519885891,1410932,10216
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6440
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,555674452,1513179,11368
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7592
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,574834155,1471921,10056
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,5153
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,457297758,1254085,10209
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6435
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,493389995,1338447,10210
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,495651951,1343255,10210
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,551078264,1473072,8846
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6440
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7592
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,5153
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient cosigns/stake,536963978,1432062,8846
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6436
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6460
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,551078264,1473072,8848
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6440
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7592
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,574834155,1471921,10056
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,5153
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,574834155,1471921,10057
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,5154
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/proposal,531423406,1440570,10657
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,6881
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,563758134,1537382,11595
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,7819
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5380
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,555674452,1513179,11190
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7414
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/proposal,555674452,1513179,11362
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7586
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,5147
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/proposal,555674452,1513179,11368
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7592
+Agora/Proposal/validator/advancing/with 5 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,5153
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/proposal,1198176494,3435790,13728
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,10590
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/proposal,373512244,1027024,8307
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5167
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/proposal,424080349,1169223,9459
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6319
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/governor,511496274,1296945,8783
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,3880
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/proposal,325703655,910129,8300
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5162
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/proposal,361795892,994491,8301
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/proposal,364057848,999299,8301
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,10590
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5167
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6319
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,3880
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient cosigns/stake,1201163379,3244679,10590
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/insufficient votes/stake,132772138,349714,5163
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/ambiguous winning effect/stake,132772138,349714,5171
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,10592
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5167
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6319
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/governor,511496274,1296945,8783
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/to next state too late/from Locked/authority,15783303,48140,3880
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/governor,511496274,1296945,8784
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,3881
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/proposal,399829303,1096614,8748
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/forget to mint GATs/stake,177634274,464336,5608
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/proposal,432164031,1193426,9686
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6546
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4107
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/proposal,424080349,1169223,9281
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6141
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/proposal,424080349,1169223,9453
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/stake,190734433,489947,6313
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/wrong GAT datum/authority,15783303,48140,3874
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/proposal,424080349,1169223,9459
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/stake,190734433,489947,6319
+Agora/Proposal/validator/advancing/with 10 cosigners and 1 effects/illegal/invalid governor output datum/authority,15783303,48140,3880
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/proposal,1238065441,3541174,14318
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,10984
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/proposal,417096077,1142396,8896
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,5560
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/proposal,463969296,1274607,10049
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,6713
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/governor,529576978,1347154,9177
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,4274
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/proposal,365592602,1015513,8889
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,5555
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/proposal,401684839,1099875,8890
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,5556
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/proposal,403946795,1104683,8890
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,5556
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,10984
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,5560
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,6713
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,4274
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient cosigns/stake,1201163379,3244679,10984
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/insufficient votes/stake,132772138,349714,5556
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/ambiguous winning effect/stake,132772138,349714,5568
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,10986
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,5560
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/stake,190734433,489947,6713
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/governor,529576978,1347154,9177
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/to next state too late/from Locked/authority,15783303,48140,4274
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/governor,529576978,1347154,9178
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,4275
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/proposal,439718250,1201998,9337
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/forget to mint GATs/stake,177634274,464336,6001
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/proposal,472052978,1298810,10276
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,6940
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,4501
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/proposal,463969296,1274607,9870
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/mint GATs with bad token name/stake,190734433,489947,6534
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/proposal,463969296,1274607,10043
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/stake,190734433,489947,6707
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/wrong GAT datum/authority,15783303,48140,4268
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/proposal,463969296,1274607,10049
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/stake,190734433,489947,6713
+Agora/Proposal/validator/advancing/with 10 cosigners and 2 effects/illegal/invalid governor output datum/authority,15783303,48140,4274
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/proposal,1357732282,3857326,16089
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Draft to VotingReady/stake,1187049093,3203669,12164
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/proposal,547847576,1488512,10668
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from VotingReady to Locked/stake,132772138,349714,6741
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/proposal,583636137,1590759,11821
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/stake,190734433,489947,7894
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/governor,583819090,1497781,10358
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to next state/from Locked to Finished/authority,15783303,48140,5455
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/proposal,485259443,1331665,10661
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Draft to Finished/stake,132772138,349714,6736
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/proposal,521351680,1416027,10662
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from VotingReady to Finished/stake,132772138,349714,6737
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/proposal,523613636,1420835,10662
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/legal/to failed state/from Locked to Finished/stake,132772138,349714,6737
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,1187049093,3203669,12164
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,132772138,349714,6741
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/stake,190734433,489947,7894
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/advance finished proposals/(negative test)/authority,15783303,48140,5455
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient cosigns/stake,1201163379,3244679,12164
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/insufficient votes/stake,132772138,349714,6737
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/ambiguous winning effect/stake,132772138,349714,6761
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Draft/stake,1187049093,3203669,12166
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from VotingReady/stake,132772138,349714,6741
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/stake,190734433,489947,7894
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/governor,583819090,1497781,10358
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/to next state too late/from Locked/authority,15783303,48140,5455
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/governor,583819090,1497781,10359
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/altered output stake datum/from Locked/authority,15783303,48140,5456
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/proposal,559385091,1518150,11109
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/forget to mint GATs/stake,177634274,464336,7182
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/proposal,591719819,1614962,12047
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/stake,194282542,497174,8120
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs for wrong validators/authority,17607300,53202,5681
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/proposal,583636137,1590759,11642
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/mint GATs with bad token name/stake,190734433,489947,7715
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/proposal,583636137,1590759,11815
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/stake,190734433,489947,7888
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/wrong GAT datum/authority,15783303,48140,5448
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/proposal,583636137,1590759,11821
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/stake,190734433,489947,7894
+Agora/Proposal/validator/advancing/with 10 cosigners and 5 effects/illegal/invalid governor output datum/authority,15783303,48140,5455
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/stake,126576208,334351,4293
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: retract votes while voting/proposal,48129948,145642,6957
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/stake,129807454,343405,4309
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,6968
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/stake,126576208,334351,4291
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/creator: remove creator locks when finished/proposal,48129948,145642,6954
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/stake,126576208,334351,4307
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,6966
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/stake,126576208,334351,4297
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,6961
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/stake,126576208,334351,4297
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,6961
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/stake,129807454,343405,4313
+Agora/Proposal/validator/unlocking/legal/with 1 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,6972
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/stake,282885452,734987,6386
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: retract votes while voting/proposal,48129948,145642,9026
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/stake,299041682,780257,6462
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,9077
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/stake,282885452,734987,6375
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/creator: remove creator locks when finished/proposal,48129948,145642,9018
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/stake,282885452,734987,6456
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,9071
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/stake,282885452,734987,6406
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,9046
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/stake,282885452,734987,6406
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,9046
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/stake,299041682,780257,6482
+Agora/Proposal/validator/unlocking/legal/with 5 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,9097
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/stake,478272007,1235782,9001
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: retract votes while voting/proposal,48129948,145642,11611
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/stake,510584467,1326322,9152
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,11712
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/stake,478272007,1235782,8981
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/creator: remove creator locks when finished/proposal,48129948,145642,11599
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/stake,478272007,1235782,9141
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,11701
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/stake,478272007,1235782,9041
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,11651
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/stake,478272007,1235782,9041
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,11651
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/stake,510584467,1326322,9192
+Agora/Proposal/validator/unlocking/legal/with 10 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,11752
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/stake,1728745959,4440870,25831
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: retract votes while voting/proposal,48129948,145642,28230
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/stake,1864458291,4821138,26518
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: retract votes while voting/proposal,48129948,145642,28688
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/stake,1728745959,4440870,25746
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/creator: remove creator locks when finished/proposal,48129948,145642,28185
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/stake,1728745959,4440870,26457
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove all locks when finished/proposal,48129948,145642,28627
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/stake,1728745959,4440870,25999
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Locked/proposal,48129948,145642,28398
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/stake,1728745959,4440870,25999
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter: unlock after voting/Finished/proposal,48129948,145642,28398
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/stake,1864458291,4821138,26687
+Agora/Proposal/validator/unlocking/legal/with 42 proposals/voter/creator: remove vote locks when locked/proposal,48129948,145642,28857
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Draft/stake",126576208,334351,4293
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Locked/stake",126576208,334351,4293
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Voter , status: Finished/stake",126576208,334351,4293
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Draft/stake",122205622,322501,4295
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Locked/stake",122205622,322501,4295
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Creator , status: Finished/stake",122205622,322501,4295
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Draft/stake",129807454,343405,4309
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Locked/stake",129807454,343405,4309
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Both , status: Finished/stake",129807454,343405,4309
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",118974376,313447,4275
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",118974376,313447,4275
+"Agora/Proposal/validator/unlocking/illegal/with 1 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,118974376,313447,4275
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Draft/stake,126576208,334351,4291
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: VotingReady/stake,126576208,334351,4291
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/remove creator too early/status: Locked/stake,126576208,334351,4291
+Agora/Proposal/validator/unlocking/illegal/with 1 proposals/creator: retract votes/stake,126576208,334351,4289
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Draft/stake",282885452,734987,6386
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Locked/stake",282885452,734987,6386
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Voter , status: Finished/stake",282885452,734987,6386
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Draft/stake",276236186,717545,6392
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Locked/stake",276236186,717545,6392
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Creator , status: Finished/stake",276236186,717545,6392
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Draft/stake",299041682,780257,6462
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Locked/stake",299041682,780257,6462
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Both , status: Finished/stake",299041682,780257,6462
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",260079956,672275,6303
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",260079956,672275,6303
+"Agora/Proposal/validator/unlocking/illegal/with 5 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,260079956,672275,6303
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Draft/stake,282885452,734987,6375
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: VotingReady/stake,282885452,734987,6375
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/remove creator too early/status: Locked/stake,282885452,734987,6375
+Agora/Proposal/validator/unlocking/illegal/with 5 proposals/creator: retract votes/stake,282885452,734987,6365
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Draft/stake",478272007,1235782,9001
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Locked/stake",478272007,1235782,9001
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Voter , status: Finished/stake",478272007,1235782,9001
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Draft/stake",468774391,1211350,9012
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Locked/stake",468774391,1211350,9012
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Creator , status: Finished/stake",468774391,1211350,9012
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Draft/stake",510584467,1326322,9152
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Locked/stake",510584467,1326322,9152
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Both , status: Finished/stake",510584467,1326322,9152
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",436461931,1120810,8838
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",436461931,1120810,8838
+"Agora/Proposal/validator/unlocking/illegal/with 10 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,436461931,1120810,8838
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Draft/stake,478272007,1235782,8981
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: VotingReady/stake,478272007,1235782,8981
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/remove creator too early/status: Locked/stake,478272007,1235782,8981
+Agora/Proposal/validator/unlocking/illegal/with 10 proposals/creator: retract votes/stake,478272007,1235782,8960
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Draft/stake",1728745959,4440870,25831
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Locked/stake",1728745959,4440870,25831
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Voter , status: Finished/stake",1728745959,4440870,25831
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Draft/stake",1701018903,4371702,25892
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Locked/stake",1701018903,4371702,25892
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Creator , status: Finished/stake",1701018903,4371702,25892
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Draft/stake",1864458291,4821138,26518
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Locked/stake",1864458291,4821138,26518
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Both , status: Finished/stake",1864458291,4821138,26518
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Draft/stake",1565306571,3991434,25118
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Locked/stake",1565306571,3991434,25118
+"Agora/Proposal/validator/unlocking/illegal/with 42 proposals/retract votes while not voting/role: Irrelevant , status: Finished/stake",1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: True/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Draft retract votes: False/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: True/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: VotingReady retract votes: False/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: True/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Locked retract votes: False/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: True/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/unlock an irrelevant stake/status: Finished retract votes: False/stake,1565306571,3991434,25118
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Draft/stake,1728745959,4440870,25746
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: VotingReady/stake,1728745959,4440870,25746
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/remove creator too early/status: Locked/stake,1728745959,4440870,25746
+Agora/Proposal/validator/unlocking/illegal/with 42 proposals/creator: retract votes/stake,1728745959,4440870,25662
+Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,19822997,52452,427
+Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32009395,84810,527
+Agora/Treasury/Validator/Positive/Allows for effect changes,30529414,78579,983
+Agora/AuthorityToken/singleAuthorityTokenBurned/Correct simple,19822997,52452,427
+Agora/AuthorityToken/singleAuthorityTokenBurned/Correct many inputs,32009395,84810,527
+Agora/Governor/policy/totally legal,67334379,187470,1867
+Agora/Governor/validator/mutate/legal,115397394,308142,6308

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,4 @@ packages: ./.
 benchmarks: true
 tests: true
 
-package plutarch
-  flags: +development
-
 test-show-details: direct

--- a/flake.lock
+++ b/flake.lock
@@ -80,6 +80,38 @@
         "type": "github"
       }
     },
+    "HTTP_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "HTTP_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "HTTP_2": {
       "flake": false,
       "locked": {
@@ -208,22 +240,6 @@
         "type": "github"
       }
     },
-    "Shrinker": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1642430208,
-        "narHash": "sha256-tfWyB7zCLzncwRpyl7eUOzuOBbg9KLu6sxSxRaFlOug=",
-        "owner": "Plutonomicon",
-        "repo": "Shrinker",
-        "rev": "0e60707996b876c7bd23a348f54545217ce2e556",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Plutonomicon",
-        "repo": "Shrinker",
-        "type": "github"
-      }
-    },
     "cabal-32": {
       "flake": false,
       "locked": {
@@ -293,6 +309,40 @@
       }
     },
     "cabal-32_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-32_15": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
@@ -530,6 +580,40 @@
         "type": "github"
       }
     },
+    "cabal-34_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-34_2": {
       "flake": false,
       "locked": {
@@ -751,6 +835,40 @@
         "type": "github"
       }
     },
+    "cabal-36_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36_2": {
       "flake": false,
       "locked": {
@@ -938,11 +1056,11 @@
     "cardano-base_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1638456794,
-        "narHash": "sha256-0KAO6dWqupJzRyjWjAFLZrt0hA6pozeKsDv1Fnysib8=",
+        "lastModified": 1652788515,
+        "narHash": "sha256-l0KgomRi6YhEoOlFnBYEXhnZO2+PW68rhfUrbMXjhCQ=",
         "owner": "input-output-hk",
         "repo": "cardano-base",
-        "rev": "4fae3f0149fd8925be94707d3ae0e36c0d67bd58",
+        "rev": "631cb6cf1fa01ab346233b610a38b3b4cba6e6ab",
         "type": "github"
       },
       "original": {
@@ -952,6 +1070,38 @@
       }
     },
     "cardano-base_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1652788515,
+        "narHash": "sha256-l0KgomRi6YhEoOlFnBYEXhnZO2+PW68rhfUrbMXjhCQ=",
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "631cb6cf1fa01ab346233b610a38b3b4cba6e6ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "type": "github"
+      }
+    },
+    "cardano-base_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1652788515,
+        "narHash": "sha256-l0KgomRi6YhEoOlFnBYEXhnZO2+PW68rhfUrbMXjhCQ=",
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "rev": "631cb6cf1fa01ab346233b610a38b3b4cba6e6ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-base",
+        "type": "github"
+      }
+    },
+    "cardano-base_15": {
       "flake": false,
       "locked": {
         "lastModified": 1652788515,
@@ -1180,6 +1330,40 @@
         "type": "github"
       }
     },
+    "cardano-crypto_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621376239,
+        "narHash": "sha256-oxIOVlgm07FAEmgGRF1C2me9TXqVxQulEOcJ22zpTRs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "07397f0e50da97eaa0575d93bee7ac4b2b2576ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "07397f0e50da97eaa0575d93bee7ac4b2b2576ec",
+        "type": "github"
+      }
+    },
+    "cardano-crypto_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1621376239,
+        "narHash": "sha256-oxIOVlgm07FAEmgGRF1C2me9TXqVxQulEOcJ22zpTRs=",
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "07397f0e50da97eaa0575d93bee7ac4b2b2576ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-crypto",
+        "rev": "07397f0e50da97eaa0575d93bee7ac4b2b2576ec",
+        "type": "github"
+      }
+    },
     "cardano-crypto_2": {
       "flake": false,
       "locked": {
@@ -1370,21 +1554,55 @@
     "cardano-prelude_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1641566029,
-        "narHash": "sha256-CylaHhO4zbZ1dEAv8yWp1swP1xys/s2Sbxg3a2pdnCI=",
-        "owner": "locallycompact",
+        "lastModified": 1653997332,
+        "narHash": "sha256-E+YSfUsvxdoOr7n7fz4xd7zb4z8XBRGNYOKipc2A1pw=",
+        "owner": "mlabs-haskell",
         "repo": "cardano-prelude",
-        "rev": "93f95047bb36a055bdd56fb0cafd887c072cdce2",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
         "type": "github"
       },
       "original": {
-        "owner": "locallycompact",
+        "owner": "mlabs-haskell",
         "repo": "cardano-prelude",
-        "rev": "93f95047bb36a055bdd56fb0cafd887c072cdce2",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
         "type": "github"
       }
     },
     "cardano-prelude_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653997332,
+        "narHash": "sha256-E+YSfUsvxdoOr7n7fz4xd7zb4z8XBRGNYOKipc2A1pw=",
+        "owner": "mlabs-haskell",
+        "repo": "cardano-prelude",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "repo": "cardano-prelude",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
+        "type": "github"
+      }
+    },
+    "cardano-prelude_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653997332,
+        "narHash": "sha256-E+YSfUsvxdoOr7n7fz4xd7zb4z8XBRGNYOKipc2A1pw=",
+        "owner": "mlabs-haskell",
+        "repo": "cardano-prelude",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "repo": "cardano-prelude",
+        "rev": "713c7ae79a4d538fcd653c976a652913df1567b9",
+        "type": "github"
+      }
+    },
+    "cardano-prelude_15": {
       "flake": false,
       "locked": {
         "lastModified": 1653997332,
@@ -1617,6 +1835,38 @@
         "type": "github"
       }
     },
+    "cardano-repo-tool_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624584417,
+        "narHash": "sha256-YSepT97PagR/1jTYV/Yer8a2GjFe9+tTwaTCHxuK50M=",
+        "owner": "input-output-hk",
+        "repo": "cardano-repo-tool",
+        "rev": "30e826ed8f00e3e154453b122a6f3d779b2f73ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-repo-tool",
+        "type": "github"
+      }
+    },
+    "cardano-repo-tool_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624584417,
+        "narHash": "sha256-YSepT97PagR/1jTYV/Yer8a2GjFe9+tTwaTCHxuK50M=",
+        "owner": "input-output-hk",
+        "repo": "cardano-repo-tool",
+        "rev": "30e826ed8f00e3e154453b122a6f3d779b2f73ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-repo-tool",
+        "type": "github"
+      }
+    },
     "cardano-repo-tool_2": {
       "flake": false,
       "locked": {
@@ -1825,6 +2075,38 @@
         "type": "github"
       }
     },
+    "cardano-shell_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
     "cardano-shell_2": {
       "flake": false,
       "locked": {
@@ -1953,1190 +2235,47 @@
         "type": "github"
       }
     },
-    "cryptonite": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1639749289,
-        "narHash": "sha256-/KS2S0f9r4c/q+IUGwkFOY9jbZkyK3dl0xMpDbULeqc=",
-        "owner": "haskell-crypto",
-        "repo": "cryptonite",
-        "rev": "cec291d988f0f17828384f3358214ab9bf724a13",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell-crypto",
-        "repo": "cryptonite",
-        "rev": "cec291d988f0f17828384f3358214ab9bf724a13",
-        "type": "github"
-      }
-    },
-    "ema": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_10": {
-      "inputs": {
-        "flake-compat": "flake-compat_19",
-        "flake-utils": "flake-utils_29",
-        "nixpkgs": "nixpkgs_49"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_11": {
-      "inputs": {
-        "flake-compat": "flake-compat_21",
-        "flake-utils": "flake-utils_32",
-        "lint-utils": "lint-utils",
-        "nixpkgs": "nixpkgs_54"
-      },
-      "locked": {
-        "lastModified": 1650932571,
-        "narHash": "sha256-rdpfJ+10a1uBPtHMNoAcpDE183RzpILRpsMgxj/YJek=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "05c8a2127391ee4b593fa6541bc9078eb44ad10f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_6"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_3": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_11"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_4": {
-      "inputs": {
-        "flake-compat": "flake-compat_7",
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_16"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_5": {
-      "inputs": {
-        "flake-compat": "flake-compat_9",
-        "flake-utils": "flake-utils_14",
-        "nixpkgs": "nixpkgs_24"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_6": {
-      "inputs": {
-        "flake-compat": "flake-compat_11",
-        "flake-utils": "flake-utils_17",
-        "nixpkgs": "nixpkgs_29"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_7": {
-      "inputs": {
-        "flake-compat": "flake-compat_13",
-        "flake-utils": "flake-utils_20",
-        "nixpkgs": "nixpkgs_34"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_8": {
-      "inputs": {
-        "flake-compat": "flake-compat_15",
-        "flake-utils": "flake-utils_23",
-        "nixpkgs": "nixpkgs_39"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "ema_9": {
-      "inputs": {
-        "flake-compat": "flake-compat_17",
-        "flake-utils": "flake-utils_26",
-        "nixpkgs": "nixpkgs_44"
-      },
-      "locked": {
-        "lastModified": 1653742730,
-        "narHash": "sha256-NyhjoMbm3h1aTskIU6jowNClSgA92bUcGcVNPfWNWgE=",
-        "owner": "srid",
-        "repo": "ema",
-        "rev": "50d9499db16b4e334776d8e8cffcd144c67f9fc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "multisite",
-        "repo": "ema",
-        "type": "github"
-      }
-    },
-    "emanote": {
-      "inputs": {
-        "ema": "ema",
-        "flake-compat": [
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist",
-        "ixset-typed": "ixset-typed",
-        "nixpkgs": [
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context",
-        "tailwind-haskell": "tailwind-haskell"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_10": {
-      "inputs": {
-        "ema": "ema_10",
-        "flake-compat": [
-          "plutarch-safe-money",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-safe-money",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_10",
-        "ixset-typed": "ixset-typed_10",
-        "nixpkgs": [
-          "plutarch-safe-money",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_10",
-        "tailwind-haskell": "tailwind-haskell_10"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_11": {
-      "inputs": {
-        "ema": "ema_11",
-        "flake-compat": [
-          "plutarch-safe-money",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-safe-money",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_11",
-        "ixset-typed": "ixset-typed_11",
-        "nixpkgs": [
-          "plutarch-safe-money",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_11",
-        "pathtree": "pathtree",
-        "tailwind-haskell": "tailwind-haskell_11",
-        "unionmount": "unionmount"
-      },
-      "locked": {
-        "lastModified": 1651699367,
-        "narHash": "sha256-f+whlGwxzv5Lcem+rxBgIgnkU+KcckogtWbRwZ6nM4I=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "2b6558fde2999ec22f645cb95322995b780f09f1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_2": {
-      "inputs": {
-        "ema": "ema_2",
-        "flake-compat": [
-          "liqwid-plutarch-extra",
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "liqwid-plutarch-extra",
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_2",
-        "ixset-typed": "ixset-typed_2",
-        "nixpkgs": [
-          "liqwid-plutarch-extra",
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_2",
-        "tailwind-haskell": "tailwind-haskell_2"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_3": {
-      "inputs": {
-        "ema": "ema_3",
-        "flake-compat": [
-          "liqwid-plutarch-extra",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "liqwid-plutarch-extra",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_3",
-        "ixset-typed": "ixset-typed_3",
-        "nixpkgs": [
-          "liqwid-plutarch-extra",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_3",
-        "tailwind-haskell": "tailwind-haskell_3"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_4": {
-      "inputs": {
-        "ema": "ema_4",
-        "flake-compat": [
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_4",
-        "ixset-typed": "ixset-typed_4",
-        "nixpkgs": [
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_4",
-        "tailwind-haskell": "tailwind-haskell_4"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_5": {
-      "inputs": {
-        "ema": "ema_5",
-        "flake-compat": [
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_5",
-        "ixset-typed": "ixset-typed_5",
-        "nixpkgs": [
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_5",
-        "tailwind-haskell": "tailwind-haskell_5"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_6": {
-      "inputs": {
-        "ema": "ema_6",
-        "flake-compat": [
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_6",
-        "ixset-typed": "ixset-typed_6",
-        "nixpkgs": [
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_6",
-        "tailwind-haskell": "tailwind-haskell_6"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_7": {
-      "inputs": {
-        "ema": "ema_7",
-        "flake-compat": [
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_7",
-        "ixset-typed": "ixset-typed_7",
-        "nixpkgs": [
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_7",
-        "tailwind-haskell": "tailwind-haskell_7"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_8": {
-      "inputs": {
-        "ema": "ema_8",
-        "flake-compat": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_8",
-        "ixset-typed": "ixset-typed_8",
-        "nixpkgs": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_8",
-        "tailwind-haskell": "tailwind-haskell_8"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "emanote_9": {
-      "inputs": {
-        "ema": "ema_9",
-        "flake-compat": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "flake-utils"
-        ],
-        "heist": "heist_9",
-        "ixset-typed": "ixset-typed_9",
-        "nixpkgs": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
-        "pandoc-link-context": "pandoc-link-context_9",
-        "tailwind-haskell": "tailwind-haskell_9"
-      },
-      "locked": {
-        "lastModified": 1653742875,
-        "narHash": "sha256-2IFMkA6/T0nCQHQcC8UhYWh8q8FQyGDBKfcDIhBJ3JM=",
-        "owner": "srid",
-        "repo": "emanote",
-        "rev": "ab5155ef400ce83a744362a4b953315d7ee6a8c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "emanote",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_12": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_13": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_14": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_15": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_16": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_17": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_18": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_19": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_20": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_21": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_22": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_23": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_24": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "flake-utils_10": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "flake-utils_11": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -3173,38 +2312,6 @@
     },
     "flake-utils_14": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_15": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_16": {
-      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -3218,39 +2325,7 @@
         "type": "github"
       }
     },
-    "flake-utils_17": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_18": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_19": {
+    "flake-utils_15": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -3267,54 +2342,6 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_20": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_21": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_22": {
-      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -3324,116 +2351,6 @@
       },
       "original": {
         "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_23": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_24": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_25": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_26": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_27": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_28": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_29": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -3453,170 +2370,32 @@
         "type": "github"
       }
     },
-    "flake-utils_30": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "ref": "v1.0.0",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_31": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_32": {
-      "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_33": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_34": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_35": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_36": {
-      "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_37": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_38": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_4": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "flake-utils_5": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -3638,32 +2417,30 @@
     },
     "flake-utils_7": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
     },
     "flake-utils_8": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "v1.0.0",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -3734,21 +2511,52 @@
     "flat_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1641898475,
-        "narHash": "sha256-D7jJ4t0T1ZvXbO61r3HQj77hZ5hWF/P1L8X9+MnfD6c=",
+        "lastModified": 1651403785,
+        "narHash": "sha256-g+jGep1IXdw4q01W67J6f6OODY91QzIlW1+Eu8pR+u0=",
         "owner": "Quid2",
         "repo": "flat",
-        "rev": "41a040c413351e021982bb78bd00f750628f8060",
+        "rev": "559617e058098b776b431e2a67346ad3adea2440",
         "type": "github"
       },
       "original": {
         "owner": "Quid2",
         "repo": "flat",
-        "rev": "41a040c413351e021982bb78bd00f750628f8060",
         "type": "github"
       }
     },
     "flat_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651403785,
+        "narHash": "sha256-g+jGep1IXdw4q01W67J6f6OODY91QzIlW1+Eu8pR+u0=",
+        "owner": "Quid2",
+        "repo": "flat",
+        "rev": "559617e058098b776b431e2a67346ad3adea2440",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Quid2",
+        "repo": "flat",
+        "type": "github"
+      }
+    },
+    "flat_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651403785,
+        "narHash": "sha256-g+jGep1IXdw4q01W67J6f6OODY91QzIlW1+Eu8pR+u0=",
+        "owner": "Quid2",
+        "repo": "flat",
+        "rev": "559617e058098b776b431e2a67346ad3adea2440",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Quid2",
+        "repo": "flat",
+        "type": "github"
+      }
+    },
+    "flat_15": {
       "flake": false,
       "locked": {
         "lastModified": 1651403785,
@@ -3892,23 +2700,6 @@
         "type": "github"
       }
     },
-    "foundation": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1635711016,
-        "narHash": "sha256-5TRuljpwt50DLjyFjiFj6quFncu8RT0d8/0jlzsenuc=",
-        "owner": "haskell-foundation",
-        "repo": "foundation",
-        "rev": "0bb195e1fea06d144dafc5af9a0ff79af0a5f4a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell-foundation",
-        "repo": "foundation",
-        "rev": "0bb195e1fea06d144dafc5af9a0ff79af0a5f4a0",
-        "type": "github"
-      }
-    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -3978,6 +2769,40 @@
       }
     },
     "ghc-8.6.5-iohk_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_15": {
       "flake": false,
       "locked": {
         "lastModified": 1600920045,
@@ -4210,6 +3035,38 @@
         "type": "github"
       }
     },
+    "gitignore-nix_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore-nix_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "gitignore-nix_2": {
       "flake": false,
       "locked": {
@@ -4405,11 +3262,11 @@
     "hackage-nix_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1644369434,
-        "narHash": "sha256-WqU6f1OhSM0UHXFW8Mhhvhz0tcij+NQVtmb6sW4RiFw=",
+        "lastModified": 1651108473,
+        "narHash": "sha256-zHGCnBdwKvrcYanjf3GARTWF8V2pyJl1QNONUNZSoc0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "644a0d702abf84cdec62f4e620ff1034000e6146",
+        "rev": "dbab3b292c3400d028a2257e3acd2ac0249da774",
         "type": "github"
       },
       "original": {
@@ -4419,6 +3276,38 @@
       }
     },
     "hackage-nix_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651108473,
+        "narHash": "sha256-zHGCnBdwKvrcYanjf3GARTWF8V2pyJl1QNONUNZSoc0=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "dbab3b292c3400d028a2257e3acd2ac0249da774",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-nix_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651108473,
+        "narHash": "sha256-zHGCnBdwKvrcYanjf3GARTWF8V2pyJl1QNONUNZSoc0=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "dbab3b292c3400d028a2257e3acd2ac0249da774",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-nix_15": {
       "flake": false,
       "locked": {
         "lastModified": 1651108473,
@@ -4597,11 +3486,11 @@
     "hackage_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1644887696,
-        "narHash": "sha256-o4gltv4npUl7+1gEQIcrRqZniwqC9kK8QsPaftlrawc=",
+        "lastModified": 1654046237,
+        "narHash": "sha256-FpM9zE+Q+WrvCiaZBCg5U1g0bYpiZOCxY8V3R5ydBu8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6ff64aa49b88e75dd6e0bbd2823c2a92c9174fa5",
+        "rev": "eeae1790b9c6a880d96e4a7214fdf0a73bdd6fc0",
         "type": "github"
       },
       "original": {
@@ -4611,6 +3500,38 @@
       }
     },
     "hackage_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654046237,
+        "narHash": "sha256-FpM9zE+Q+WrvCiaZBCg5U1g0bYpiZOCxY8V3R5ydBu8=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "eeae1790b9c6a880d96e4a7214fdf0a73bdd6fc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654046237,
+        "narHash": "sha256-FpM9zE+Q+WrvCiaZBCg5U1g0bYpiZOCxY8V3R5ydBu8=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "eeae1790b9c6a880d96e4a7214fdf0a73bdd6fc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage_15": {
       "flake": false,
       "locked": {
         "lastModified": 1654046237,
@@ -4757,11 +3678,11 @@
     "haskell-language-server": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
@@ -4773,15 +3694,16 @@
     "haskell-language-server_10": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -4855,22 +3777,6 @@
     "haskell-language-server_15": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_16": {
-      "flake": false,
-      "locked": {
         "lastModified": 1653778781,
         "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
@@ -4884,7 +3790,7 @@
         "type": "github"
       }
     },
-    "haskell-language-server_17": {
+    "haskell-language-server_16": {
       "flake": false,
       "locked": {
         "lastModified": 1650980856,
@@ -4901,18 +3807,35 @@
         "type": "github"
       }
     },
-    "haskell-language-server_18": {
+    "haskell-language-server_17": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "haskell-language-server_18": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -4936,15 +3859,16 @@
     "haskell-language-server_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1653778781,
-        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -4969,11 +3893,11 @@
     "haskell-language-server_21": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
@@ -4985,6 +3909,23 @@
     "haskell-language-server_22": {
       "flake": false,
       "locked": {
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "haskell-language-server_23": {
+      "flake": false,
+      "locked": {
         "lastModified": 1653778781,
         "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
@@ -4998,7 +3939,7 @@
         "type": "github"
       }
     },
-    "haskell-language-server_23": {
+    "haskell-language-server_24": {
       "flake": false,
       "locked": {
         "lastModified": 1650980856,
@@ -5015,30 +3956,14 @@
         "type": "github"
       }
     },
-    "haskell-language-server_24": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "haskell-language-server_25": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
@@ -5050,22 +3975,6 @@
     "haskell-language-server_26": {
       "flake": false,
       "locked": {
-        "lastModified": 1653778781,
-        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_27": {
-      "flake": false,
-      "locked": {
         "lastModified": 1650980856,
         "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
         "owner": "haskell",
@@ -5080,18 +3989,35 @@
         "type": "github"
       }
     },
-    "haskell-language-server_28": {
+    "haskell-language-server_27": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "haskell-language-server_28": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -5115,16 +4041,15 @@
     "haskell-language-server_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1650980856,
-        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -5146,133 +4071,19 @@
         "type": "github"
       }
     },
-    "haskell-language-server_31": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653778781,
-        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650980856,
-        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_33": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1655140576,
-        "narHash": "sha256-mHJuIk1ElmgPxvEUO2Y3E6T674F2tO5SS/uixf4R2fM=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "8a5840a020048c74285f9997b9b02b9b04c658c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645014262,
-        "narHash": "sha256-f49So1teiroV+S7sbGTK4AhzUOXpoiQ26/fTjdIKkqc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "96ea854debd92f9a54e2270b9b9a080c0ce6f3d1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_35": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1643835246,
-        "narHash": "sha256-5LQHcQmi3mUGRgJu+X/m3jeM3kdkYjLD+KwgnxBlbeU=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "024ddc8b3904f8b8e8fe67ba6b9ebd8a4bd7ce76",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.6.1.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653778781,
-        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_37": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650980856,
-        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "haskell-language-server_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
+        "lastModified": 1650980856,
+        "narHash": "sha256-uiwsfh/K3IABZDYj7JUZNIAPRVqH6g/r8X6QKg8DrZE=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
+        "rev": "b5a37f7fc360596899cb2945f363030f44156415",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
+        "ref": "1.7.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -5313,22 +4124,6 @@
     "haskell-language-server_7": {
       "flake": false,
       "locked": {
-        "lastModified": 1654120290,
-        "narHash": "sha256-6NuFBnEzJPvWfvbYxXk/WCQDjsEbjCQ1nAelhBDi4yQ=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "140f9040ae88352ca1140a750e7c26485fdfbe17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "haskell-language-server_8": {
-      "flake": false,
-      "locked": {
         "lastModified": 1653778781,
         "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
         "owner": "haskell",
@@ -5342,7 +4137,7 @@
         "type": "github"
       }
     },
-    "haskell-language-server_9": {
+    "haskell-language-server_8": {
       "flake": false,
       "locked": {
         "lastModified": 1650980856,
@@ -5359,6 +4154,22 @@
         "type": "github"
       }
     },
+    "haskell-language-server_9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653778781,
+        "narHash": "sha256-oEVBaYRLjD4gC3vQuT0DCgmCSIeWSwGPVXXSKJDFUK0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "8c47d6ce2a8409a285a3f4c3f0e10c25fb4dd848",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
         "HTTP": "HTTP",
@@ -5366,7 +4177,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
@@ -5413,15 +4224,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5431,6 +4243,70 @@
         "haskell-nix": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix"
+        ],
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
+        "owner": "mlabs-haskell",
+        "repo": "haskell-nix-extra-hackage",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
+        "repo": "haskell-nix-extra-hackage",
+        "type": "github"
+      }
+    },
+    "haskell-nix-extra-hackage_11": {
+      "inputs": {
+        "haskell-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix"
+        ],
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
+        "owner": "mlabs-haskell",
+        "repo": "haskell-nix-extra-hackage",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
+        "repo": "haskell-nix-extra-hackage",
+        "type": "github"
+      }
+    },
+    "haskell-nix-extra-hackage_12": {
+      "inputs": {
+        "haskell-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
           "plutarch-quickcheck",
           "plutarch",
           "haskell-nix"
@@ -5444,20 +4320,21 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
     },
-    "haskell-nix-extra-hackage_11": {
+    "haskell-nix-extra-hackage_13": {
       "inputs": {
         "haskell-nix": [
           "plutarch-safe-money",
@@ -5471,20 +4348,51 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
     },
-    "haskell-nix-extra-hackage_12": {
+    "haskell-nix-extra-hackage_14": {
+      "inputs": {
+        "haskell-nix": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix"
+        ],
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
+        "owner": "mlabs-haskell",
+        "repo": "haskell-nix-extra-hackage",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
+        "repo": "haskell-nix-extra-hackage",
+        "type": "github"
+      }
+    },
+    "haskell-nix-extra-hackage_15": {
       "inputs": {
         "haskell-nix": [
           "plutarch-script-export",
@@ -5498,15 +4406,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5527,15 +4436,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5556,15 +4466,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5585,15 +4496,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5610,15 +4522,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5637,15 +4550,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5664,15 +4578,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5691,15 +4606,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5720,15 +4636,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1653405678,
-        "narHash": "sha256-fPpPxuCZDF5b/iQgmUg2jspPObsK0mpcchUti/LR8D0=",
+        "lastModified": 1655143375,
+        "narHash": "sha256-yU+HPLwGPf5IeLj9IBQ1zrPBTYEwvYbuMnADs4T8RLQ=",
         "owner": "mlabs-haskell",
         "repo": "haskell-nix-extra-hackage",
-        "rev": "cf4613eb0d883a8c12c86d7cdbdaaf15fdc70128",
+        "rev": "03ee7afdc1ad982e059e3941db80f7a5b30a2757",
         "type": "github"
       },
       "original": {
         "owner": "mlabs-haskell",
+        "ref": "separate-hackages",
         "repo": "haskell-nix-extra-hackage",
         "type": "github"
       }
@@ -5756,7 +4673,7 @@
         "cabal-34": "cabal-34_6",
         "cabal-36": "cabal-36_6",
         "cardano-shell": "cardano-shell_6",
-        "flake-utils": "flake-utils_16",
+        "flake-utils": "flake-utils_6",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
         "hackage": "hackage_6",
         "hpc-coveralls": "hpc-coveralls_6",
@@ -5812,7 +4729,7 @@
         "cabal-34": "cabal-34_7",
         "cabal-36": "cabal-36_7",
         "cardano-shell": "cardano-shell_7",
-        "flake-utils": "flake-utils_19",
+        "flake-utils": "flake-utils_7",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
         "hackage": "hackage_7",
         "hpc-coveralls": "hpc-coveralls_7",
@@ -5868,7 +4785,7 @@
         "cabal-34": "cabal-34_8",
         "cabal-36": "cabal-36_8",
         "cardano-shell": "cardano-shell_8",
-        "flake-utils": "flake-utils_22",
+        "flake-utils": "flake-utils_8",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
         "hackage": "hackage_8",
         "hpc-coveralls": "hpc-coveralls_8",
@@ -5924,7 +4841,7 @@
         "cabal-34": "cabal-34_9",
         "cabal-36": "cabal-36_9",
         "cardano-shell": "cardano-shell_9",
-        "flake-utils": "flake-utils_25",
+        "flake-utils": "flake-utils_9",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
         "hackage": "hackage_9",
         "hpc-coveralls": "hpc-coveralls_9",
@@ -5981,7 +4898,7 @@
         "cabal-34": "cabal-34_10",
         "cabal-36": "cabal-36_10",
         "cardano-shell": "cardano-shell_10",
-        "flake-utils": "flake-utils_28",
+        "flake-utils": "flake-utils_10",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
         "hackage": "hackage_10",
         "hpc-coveralls": "hpc-coveralls_10",
@@ -5990,7 +4907,7 @@
         "nixpkgs": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
+          "plutarch-context-builder",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -6055,7 +4972,7 @@
         "cabal-34": "cabal-34_11",
         "cabal-36": "cabal-36_11",
         "cardano-shell": "cardano-shell_11",
-        "flake-utils": "flake-utils_31",
+        "flake-utils": "flake-utils_11",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_11",
         "hackage": "hackage_11",
         "hpc-coveralls": "hpc-coveralls_11",
@@ -6063,6 +4980,8 @@
         "nix-tools": "nix-tools_11",
         "nixpkgs": [
           "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -6111,14 +5030,16 @@
         "cabal-34": "cabal-34_12",
         "cabal-36": "cabal-36_12",
         "cardano-shell": "cardano-shell_12",
-        "flake-utils": "flake-utils_37",
+        "flake-utils": "flake-utils_12",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_12",
         "hackage": "hackage_12",
         "hpc-coveralls": "hpc-coveralls_12",
+        "hydra": "hydra_12",
         "nix-tools": "nix-tools_12",
         "nixpkgs": [
           "plutarch-safe-money",
-          "plutarch-numeric",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -6131,16 +5052,15 @@
         "stackage": "stackage_12"
       },
       "locked": {
-        "lastModified": 1644944726,
-        "narHash": "sha256-jJWdP/3Ne1y1akC3m9rSO5ItRoBc4UTdVQZBCuPmmrM=",
-        "owner": "L-as",
+        "lastModified": 1654068838,
+        "narHash": "sha256-GHSufC21DSg8Lz2AzIg3DA9DPxGvLqxGFa/4ADoXRhU=",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "45c583b5580c130487eb5a342679f0bdbc2b23fc",
+        "rev": "fa2fa131fe15e630c91ab4078d12eb32c41f934b",
         "type": "github"
       },
       "original": {
-        "owner": "L-as",
-        "ref": "master",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -6148,11 +5068,11 @@
     "haskell-nix_24": {
       "flake": false,
       "locked": {
-        "lastModified": 1629380841,
-        "narHash": "sha256-gWOWCfX7IgVSvMMYN6rBGK6EA0pk6pmYguXzMvGte+Q=",
+        "lastModified": 1651151636,
+        "narHash": "sha256-WdMP9IMB5kByT0zimDuCYZF/dinRB104H8iDTG/c1Eo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7215f083b37741446aa325b20c8ba9f9f76015eb",
+        "rev": "f707aa2e75c0d33473166abc61c0b43ac6e107c0",
         "type": "github"
       },
       "original": {
@@ -6168,14 +5088,14 @@
         "cabal-34": "cabal-34_13",
         "cabal-36": "cabal-36_13",
         "cardano-shell": "cardano-shell_13",
-        "flake-utils": "flake-utils_38",
+        "flake-utils": "flake-utils_13",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_13",
         "hackage": "hackage_13",
         "hpc-coveralls": "hpc-coveralls_13",
-        "hydra": "hydra_12",
+        "hydra": "hydra_13",
         "nix-tools": "nix-tools_13",
         "nixpkgs": [
-          "plutarch-script-export",
+          "plutarch-safe-money",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -6217,6 +5137,103 @@
         "type": "github"
       }
     },
+    "haskell-nix_27": {
+      "inputs": {
+        "HTTP": "HTTP_14",
+        "cabal-32": "cabal-32_14",
+        "cabal-34": "cabal-34_14",
+        "cabal-36": "cabal-36_14",
+        "cardano-shell": "cardano-shell_14",
+        "flake-utils": "flake-utils_14",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_14",
+        "hackage": "hackage_14",
+        "hpc-coveralls": "hpc-coveralls_14",
+        "hydra": "hydra_14",
+        "nix-tools": "nix-tools_14",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_14",
+        "nixpkgs-2105": "nixpkgs-2105_14",
+        "nixpkgs-2111": "nixpkgs-2111_28",
+        "nixpkgs-unstable": "nixpkgs-unstable_14",
+        "old-ghc-nix": "old-ghc-nix_14",
+        "stackage": "stackage_14"
+      },
+      "locked": {
+        "lastModified": 1654068838,
+        "narHash": "sha256-GHSufC21DSg8Lz2AzIg3DA9DPxGvLqxGFa/4ADoXRhU=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "fa2fa131fe15e630c91ab4078d12eb32c41f934b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix_28": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651151636,
+        "narHash": "sha256-WdMP9IMB5kByT0zimDuCYZF/dinRB104H8iDTG/c1Eo=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "f707aa2e75c0d33473166abc61c0b43ac6e107c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix_29": {
+      "inputs": {
+        "HTTP": "HTTP_15",
+        "cabal-32": "cabal-32_15",
+        "cabal-34": "cabal-34_15",
+        "cabal-36": "cabal-36_15",
+        "cardano-shell": "cardano-shell_15",
+        "flake-utils": "flake-utils_15",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_15",
+        "hackage": "hackage_15",
+        "hpc-coveralls": "hpc-coveralls_15",
+        "hydra": "hydra_15",
+        "nix-tools": "nix-tools_15",
+        "nixpkgs": [
+          "plutarch-script-export",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_15",
+        "nixpkgs-2105": "nixpkgs-2105_15",
+        "nixpkgs-2111": "nixpkgs-2111_30",
+        "nixpkgs-unstable": "nixpkgs-unstable_15",
+        "old-ghc-nix": "old-ghc-nix_15",
+        "stackage": "stackage_15"
+      },
+      "locked": {
+        "lastModified": 1654068838,
+        "narHash": "sha256-GHSufC21DSg8Lz2AzIg3DA9DPxGvLqxGFa/4ADoXRhU=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "fa2fa131fe15e630c91ab4078d12eb32c41f934b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "haskell-nix_3": {
       "inputs": {
         "HTTP": "HTTP_2",
@@ -6224,7 +5241,7 @@
         "cabal-34": "cabal-34_2",
         "cabal-36": "cabal-36_2",
         "cardano-shell": "cardano-shell_2",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_2",
@@ -6258,6 +5275,22 @@
         "type": "github"
       }
     },
+    "haskell-nix_30": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651151636,
+        "narHash": "sha256-WdMP9IMB5kByT0zimDuCYZF/dinRB104H8iDTG/c1Eo=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "f707aa2e75c0d33473166abc61c0b43ac6e107c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "haskell-nix_4": {
       "flake": false,
       "locked": {
@@ -6281,7 +5314,7 @@
         "cabal-34": "cabal-34_3",
         "cabal-36": "cabal-36_3",
         "cardano-shell": "cardano-shell_3",
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
         "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_3",
@@ -6338,7 +5371,7 @@
         "cabal-34": "cabal-34_4",
         "cabal-36": "cabal-36_4",
         "cardano-shell": "cardano-shell_4",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
         "hackage": "hackage_4",
         "hpc-coveralls": "hpc-coveralls_4",
@@ -6395,7 +5428,7 @@
         "cabal-34": "cabal-34_5",
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_5",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
         "hackage": "hackage_5",
         "hpc-coveralls": "hpc-coveralls_5",
@@ -6427,193 +5460,6 @@
         "type": "github"
       }
     },
-    "heist": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1649279862,
-        "narHash": "sha256-YPD7Qv1ZcXM4uAlsZ2P/2CKen4H2OY3VHHGluYFVulg=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "085c7ab88b73079de27c8def27d67f03853fde05",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote-release--ghc9",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
-    "heist_9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653169917,
-        "narHash": "sha256-i52wi4nNC6ATx8gTtmpLnxQZEhKSM0LbpmSu57d5VqI=",
-        "owner": "srid",
-        "repo": "heist",
-        "rev": "75533cade1a0d9859ff487cbf6f22e98711248d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "emanote",
-        "repo": "heist",
-        "type": "github"
-      }
-    },
     "hercules-ci-effects": {
       "inputs": {
         "nixpkgs": "nixpkgs_4"
@@ -6634,7 +5480,7 @@
     },
     "hercules-ci-effects_10": {
       "inputs": {
-        "nixpkgs": "nixpkgs_47"
+        "nixpkgs": "nixpkgs_40"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6652,7 +5498,7 @@
     },
     "hercules-ci-effects_11": {
       "inputs": {
-        "nixpkgs": "nixpkgs_52"
+        "nixpkgs": "nixpkgs_44"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6670,14 +5516,14 @@
     },
     "hercules-ci-effects_12": {
       "inputs": {
-        "nixpkgs": "nixpkgs_58"
+        "nixpkgs": "nixpkgs_48"
       },
       "locked": {
-        "lastModified": 1647711660,
-        "narHash": "sha256-ZoV/oAH8g4NYeTzC7OCZnlM7l0hNBs0nUHf4l1+lmDc=",
+        "lastModified": 1653841712,
+        "narHash": "sha256-XBF4i1MuIRAEbFpj3Z3fVaYxzNEsYapyENtw3vG+q1I=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "d17e41cfb454d07f5d8d3b667bf45b079d868541",
+        "rev": "e14d2131b7c81acca3904b584ac45fb72da64dd2",
         "type": "github"
       },
       "original": {
@@ -6688,7 +5534,43 @@
     },
     "hercules-ci-effects_13": {
       "inputs": {
-        "nixpkgs": "nixpkgs_61"
+        "nixpkgs": "nixpkgs_51"
+      },
+      "locked": {
+        "lastModified": 1653841712,
+        "narHash": "sha256-XBF4i1MuIRAEbFpj3Z3fVaYxzNEsYapyENtw3vG+q1I=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "e14d2131b7c81acca3904b584ac45fb72da64dd2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects_14": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_55"
+      },
+      "locked": {
+        "lastModified": 1653841712,
+        "narHash": "sha256-XBF4i1MuIRAEbFpj3Z3fVaYxzNEsYapyENtw3vG+q1I=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "e14d2131b7c81acca3904b584ac45fb72da64dd2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects_15": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_59"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6706,7 +5588,7 @@
     },
     "hercules-ci-effects_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6724,7 +5606,7 @@
     },
     "hercules-ci-effects_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6742,7 +5624,7 @@
     },
     "hercules-ci-effects_4": {
       "inputs": {
-        "nixpkgs": "nixpkgs_19"
+        "nixpkgs": "nixpkgs_16"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6760,7 +5642,7 @@
     },
     "hercules-ci-effects_5": {
       "inputs": {
-        "nixpkgs": "nixpkgs_22"
+        "nixpkgs": "nixpkgs_19"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6778,7 +5660,7 @@
     },
     "hercules-ci-effects_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_27"
+        "nixpkgs": "nixpkgs_23"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6796,7 +5678,7 @@
     },
     "hercules-ci-effects_7": {
       "inputs": {
-        "nixpkgs": "nixpkgs_32"
+        "nixpkgs": "nixpkgs_27"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6814,7 +5696,7 @@
     },
     "hercules-ci-effects_8": {
       "inputs": {
-        "nixpkgs": "nixpkgs_37"
+        "nixpkgs": "nixpkgs_31"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6832,7 +5714,7 @@
     },
     "hercules-ci-effects_9": {
       "inputs": {
-        "nixpkgs": "nixpkgs_42"
+        "nixpkgs": "nixpkgs_36"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -6913,6 +5795,38 @@
       }
     },
     "hpc-coveralls_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_15": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -7056,72 +5970,6 @@
         "type": "github"
       }
     },
-    "hs-memory": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1636757734,
-        "narHash": "sha256-DIlt0NpFUx8IUeTcgZNBJWWfyNaKv5ZKYw1K9aLvxBs=",
-        "owner": "vincenthz",
-        "repo": "hs-memory",
-        "rev": "3cf661a8a9a8ac028df77daa88e8d65c55a3347a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vincenthz",
-        "repo": "hs-memory",
-        "rev": "3cf661a8a9a8ac028df77daa88e8d65c55a3347a",
-        "type": "github"
-      }
-    },
-    "hspec": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1649095108,
-        "narHash": "sha256-cPmt4hvmdh727VT6UAL8yFArmm4FAWeg3K5Qi3XtU4g=",
-        "owner": "srid",
-        "repo": "hspec",
-        "rev": "44f2a143e10c93df237af428457d0e4b74ae270a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "askAncestors",
-        "repo": "hspec",
-        "type": "github"
-      }
-    },
-    "hspec-golden": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648755064,
-        "narHash": "sha256-5a6BksZx00o2iL0Ei/L1Kkou2BsnsIagN+tTmqYyKfs=",
-        "owner": "stackbuilders",
-        "repo": "hspec-golden",
-        "rev": "4b0ad56b2de0254a7b1e0feda917656f78a5bcda",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stackbuilders",
-        "repo": "hspec-golden",
-        "type": "github"
-      }
-    },
-    "hspec-hedgehog": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1602603478,
-        "narHash": "sha256-XnS3zjQ7eh3iBOWq+Z/YcwrfWI55hV6k8LsZ8qm/qOc=",
-        "owner": "parsonsmatt",
-        "repo": "hspec-hedgehog",
-        "rev": "eb617d854542510f0129acdea4bf52e50b13042e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "parsonsmatt",
-        "repo": "hspec-hedgehog",
-        "type": "github"
-      }
-    },
     "hydra": {
       "inputs": {
         "nix": "nix",
@@ -7153,7 +6001,7 @@
         "nixpkgs": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
+          "plutarch-context-builder",
           "plutarch",
           "haskell-nix",
           "hydra",
@@ -7179,6 +6027,8 @@
         "nix": "nix_11",
         "nixpkgs": [
           "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
           "plutarch",
           "haskell-nix",
           "hydra",
@@ -7202,6 +6052,84 @@
     "hydra_12": {
       "inputs": {
         "nix": "nix_12",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_13": {
+      "inputs": {
+        "nix": "nix_13",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_14": {
+      "inputs": {
+        "nix": "nix_14",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_15": {
+      "inputs": {
+        "nix": "nix_15",
         "nixpkgs": [
           "plutarch-script-export",
           "plutarch",
@@ -7670,11 +6598,11 @@
     "iohk-nix_23": {
       "flake": false,
       "locked": {
-        "lastModified": 1643251385,
-        "narHash": "sha256-Czbd69lg0ARSZfC18V6h+gtPMioWDAEVPbiHgL2x9LM=",
+        "lastModified": 1653579289,
+        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "9d6ee3dcb3482f791e40ed991ad6fc649b343ad4",
+        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
         "type": "github"
       },
       "original": {
@@ -7731,6 +6659,54 @@
         "type": "github"
       }
     },
+    "iohk-nix_27": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653579289,
+        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohk-nix_28": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1626953580,
+        "narHash": "sha256-iEI9aTOaZMGsjWzcrctrC0usmiagwKT2v1LSDe9/tMU=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "cbd497f5844249ef8fe617166337d59f2a6ebe90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohk-nix_29": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653579289,
+        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iohk-nix_3": {
       "flake": false,
       "locked": {
@@ -7739,6 +6715,22 @@
         "owner": "input-output-hk",
         "repo": "iohk-nix",
         "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohk-nix_30": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1626953580,
+        "narHash": "sha256-iEI9aTOaZMGsjWzcrctrC0usmiagwKT2v1LSDe9/tMU=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "cbd497f5844249ef8fe617166337d59f2a6ebe90",
         "type": "github"
       },
       "original": {
@@ -7843,217 +6835,302 @@
         "type": "github"
       }
     },
-    "ixset-typed": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1639657838,
-        "narHash": "sha256-pI2dzJfkR10CHDEX6TV2E01pqcGkj7kheROw05MRTR8=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "6cf16f77ae173311742623e5f0b308a21b337aa7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "ixset-typed_9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1652177108,
-        "narHash": "sha256-g0N1jiumsxHzfo9SGVR+q9awRvHEehSRaoW89LXCCnY=",
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "rev": "244d3b72fd051b8d78f2d4edb6208269f29d85b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "well-typed",
-        "repo": "ixset-typed",
-        "type": "github"
-      }
-    },
-    "lint-utils": {
+    "liqwid-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_33",
-        "nixpkgs": [
-          "plutarch-safe-money",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-2205": "nixpkgs-2205"
       },
       "locked": {
-        "lastModified": 1650427214,
-        "narHash": "sha256-9m66rRSSM614ocRXNPAArwnrS6zzCQYYhd3nw8g4QUg=",
-        "ref": "overengineered",
-        "rev": "5555def5a25c5437834c06cbe79b3945916ec59f",
-        "revCount": 28,
-        "type": "git",
-        "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
+        "lastModified": 1660251224,
+        "narHash": "sha256-spBrASFpblmQFYuS4GHv9hI3cLRzh6OG5tNikRmUUZA=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "6bf26da0cbd1dea4ea275ffb5d05214a7d3e61be",
+        "type": "github"
       },
       "original": {
-        "ref": "overengineered",
-        "type": "git",
-        "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
+        "owner": "Liqwid-Labs",
+        "ref": "main",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_10": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_34"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_11": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_38"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_12": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_42"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_13": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_46"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_14": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_53"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_15": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_57",
+        "nixpkgs-2205": "nixpkgs-2205_2"
+      },
+      "locked": {
+        "lastModified": 1660165784,
+        "narHash": "sha256-uSwB6jmiP0giQM9NwCkXloabfRnbDSsd1EAKXbTQpq4=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "07d35ade0f9a1bab07413d059ccec63982592552",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_5": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_14"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_6": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_21"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_25"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_8": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_29"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
+      }
+    },
+    "liqwid-nix_9": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_33"
+      },
+      "locked": {
+        "lastModified": 1659383708,
+        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "repo": "liqwid-nix",
+        "type": "github"
       }
     },
     "liqwid-plutarch-extra": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server",
+        "haskell-language-server": [
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "liqwid-plutarch-extra",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_2",
         "nixpkgs": [
           "liqwid-plutarch-extra",
           "plutarch",
@@ -8067,29 +7144,47 @@
         "plutarch-quickcheck": "plutarch-quickcheck"
       },
       "locked": {
-        "lastModified": 1658864114,
-        "narHash": "sha256-6lMJubbJOVNFe/chEFmbGStI+Pm7zy1+t2wPcDVSiv8=",
+        "lastModified": 1660162748,
+        "narHash": "sha256-TvDWZ3mbfQCKHgNDjRR2Ydjx9cgw48hDpN0t/wy7oCI=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-plutarch-extra",
-        "rev": "fb6d4d1fc73b1c5ff90b5356e8cb3367213aeae0",
+        "rev": "d8be5f8dc91ad00158727fdbccb6db849e9f3559",
         "type": "github"
       },
       "original": {
         "owner": "Liqwid-Labs",
-        "ref": "seungheonoh/agoraUtils",
+        "ref": "plutus-v1",
         "repo": "liqwid-plutarch-extra",
         "type": "github"
       }
     },
     "liqwid-plutarch-extra_2": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_25",
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_10",
         "nixpkgs": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
@@ -8099,14 +7194,16 @@
         "nixpkgs-2111": "nixpkgs-2111_17",
         "nixpkgs-latest": "nixpkgs-latest_17",
         "plutarch": "plutarch_9",
+        "plutarch-context-builder": "plutarch-context-builder_3",
+        "plutarch-numeric": "plutarch-numeric_3",
         "plutarch-quickcheck": "plutarch-quickcheck_3"
       },
       "locked": {
-        "lastModified": 1655470312,
-        "narHash": "sha256-O4Dy803SFOS+S1OFEecfCRkjWc8y0iHbO+EVKtBqsGk=",
+        "lastModified": 1659473759,
+        "narHash": "sha256-hHGEaISfdUyrQEh5OeBD4IEn0xwCdR1vfk3c+yfxeaw=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-plutarch-extra",
-        "rev": "fd9b2e6e713c36efef30bcef8d97a069fda7d71a",
+        "rev": "6ddf927299f8f1681092253f0297df549b8a74b6",
         "type": "github"
       },
       "original": {
@@ -8165,6 +7262,54 @@
       }
     },
     "lowdown-src_12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_15": {
       "flake": false,
       "locked": {
         "lastModified": 1633514407,
@@ -8380,11 +7525,11 @@
     "nix-tools_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1644395812,
-        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
         "type": "github"
       },
       "original": {
@@ -8394,6 +7539,38 @@
       }
     },
     "nix-tools_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_15": {
       "flake": false,
       "locked": {
         "lastModified": 1649424170,
@@ -8540,7 +7717,7 @@
     "nix_10": {
       "inputs": {
         "lowdown-src": "lowdown-src_10",
-        "nixpkgs": "nixpkgs_46",
+        "nixpkgs": "nixpkgs_39",
         "nixpkgs-regression": "nixpkgs-regression_10"
       },
       "locked": {
@@ -8561,7 +7738,7 @@
     "nix_11": {
       "inputs": {
         "lowdown-src": "lowdown-src_11",
-        "nixpkgs": "nixpkgs_51",
+        "nixpkgs": "nixpkgs_43",
         "nixpkgs-regression": "nixpkgs-regression_11"
       },
       "locked": {
@@ -8582,8 +7759,71 @@
     "nix_12": {
       "inputs": {
         "lowdown-src": "lowdown-src_12",
-        "nixpkgs": "nixpkgs_60",
+        "nixpkgs": "nixpkgs_47",
         "nixpkgs-regression": "nixpkgs-regression_12"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_13": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_13",
+        "nixpkgs": "nixpkgs_50",
+        "nixpkgs-regression": "nixpkgs-regression_13"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_14": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_14",
+        "nixpkgs": "nixpkgs_54",
+        "nixpkgs-regression": "nixpkgs-regression_14"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_15": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_15",
+        "nixpkgs": "nixpkgs_58",
+        "nixpkgs-regression": "nixpkgs-regression_15"
       },
       "locked": {
         "lastModified": 1643066034,
@@ -8603,7 +7843,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -8624,7 +7864,7 @@
     "nix_3": {
       "inputs": {
         "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_11",
         "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
@@ -8645,7 +7885,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_18",
+        "nixpkgs": "nixpkgs_15",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -8666,7 +7906,7 @@
     "nix_5": {
       "inputs": {
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_21",
+        "nixpkgs": "nixpkgs_18",
         "nixpkgs-regression": "nixpkgs-regression_5"
       },
       "locked": {
@@ -8687,7 +7927,7 @@
     "nix_6": {
       "inputs": {
         "lowdown-src": "lowdown-src_6",
-        "nixpkgs": "nixpkgs_26",
+        "nixpkgs": "nixpkgs_22",
         "nixpkgs-regression": "nixpkgs-regression_6"
       },
       "locked": {
@@ -8708,7 +7948,7 @@
     "nix_7": {
       "inputs": {
         "lowdown-src": "lowdown-src_7",
-        "nixpkgs": "nixpkgs_31",
+        "nixpkgs": "nixpkgs_26",
         "nixpkgs-regression": "nixpkgs-regression_7"
       },
       "locked": {
@@ -8729,7 +7969,7 @@
     "nix_8": {
       "inputs": {
         "lowdown-src": "lowdown-src_8",
-        "nixpkgs": "nixpkgs_36",
+        "nixpkgs": "nixpkgs_30",
         "nixpkgs-regression": "nixpkgs-regression_8"
       },
       "locked": {
@@ -8750,7 +7990,7 @@
     "nix_9": {
       "inputs": {
         "lowdown-src": "lowdown-src_9",
-        "nixpkgs": "nixpkgs_41",
+        "nixpkgs": "nixpkgs_35",
         "nixpkgs-regression": "nixpkgs-regression_9"
       },
       "locked": {
@@ -8770,18 +8010,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs-2003": {
@@ -8849,6 +8087,38 @@
       }
     },
     "nixpkgs-2003_13": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_14": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_15": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -9042,11 +8312,11 @@
     },
     "nixpkgs-2105_12": {
       "locked": {
-        "lastModified": 1642244250,
-        "narHash": "sha256-vWpUEqQdVP4srj+/YLJRTN9vjpTs4je0cdWKXPbDItc=",
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
         "type": "github"
       },
       "original": {
@@ -9057,6 +8327,38 @@
       }
     },
     "nixpkgs-2105_13": {
+      "locked": {
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_14": {
+      "locked": {
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_15": {
       "locked": {
         "lastModified": 1645296114,
         "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
@@ -9202,11 +8504,11 @@
     },
     "nixpkgs-2111": {
       "locked": {
-        "lastModified": 1654115789,
-        "narHash": "sha256-k9Qr8dLrmgEn+xIVbneJdQgCYG8FbbqOrTVaExUrLFI=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bce6d15455f8c15c9ef511368947e7ef789c5316",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9234,11 +8536,11 @@
     },
     "nixpkgs-2111_11": {
       "locked": {
-        "lastModified": 1652298859,
-        "narHash": "sha256-hcwRboK+NxMWUJh0fQ3VsocDcAHrYJ95FmPEHlddV0Y=",
+        "lastModified": 1659375853,
+        "narHash": "sha256-aiMfO6U1w1u93vB+5qCHCQDZKgpJ7qs4GJOQvI3CN/4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "051448e41537c3463ae776d46115d01afb6c498d",
+        "rev": "511f6a5c3248f9019a41e70c1891484de2bc906c",
         "type": "github"
       },
       "original": {
@@ -9266,11 +8568,11 @@
     },
     "nixpkgs-2111_13": {
       "locked": {
-        "lastModified": 1653319070,
-        "narHash": "sha256-Z3cv967iN6mXgxhq1cjOoPod23XgNttCWHXMnMZUq9E=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c813bbdc330b45fe922c642eb610902aecd5673",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9298,11 +8600,11 @@
     },
     "nixpkgs-2111_15": {
       "locked": {
-        "lastModified": 1652364845,
-        "narHash": "sha256-1pG2GR+z7IrUVGcMoTsH6nJ+ACMvBplo/Pyw4SXJDIE=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee80943d4d1160f460e3d719222212dbfbc6a193",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9330,11 +8632,11 @@
     },
     "nixpkgs-2111_17": {
       "locked": {
-        "lastModified": 1654115789,
-        "narHash": "sha256-k9Qr8dLrmgEn+xIVbneJdQgCYG8FbbqOrTVaExUrLFI=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bce6d15455f8c15c9ef511368947e7ef789c5316",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9362,11 +8664,11 @@
     },
     "nixpkgs-2111_19": {
       "locked": {
-        "lastModified": 1652364845,
-        "narHash": "sha256-1pG2GR+z7IrUVGcMoTsH6nJ+ACMvBplo/Pyw4SXJDIE=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee80943d4d1160f460e3d719222212dbfbc6a193",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9410,11 +8712,11 @@
     },
     "nixpkgs-2111_21": {
       "locked": {
-        "lastModified": 1653319070,
-        "narHash": "sha256-Z3cv967iN6mXgxhq1cjOoPod23XgNttCWHXMnMZUq9E=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c813bbdc330b45fe922c642eb610902aecd5673",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9442,11 +8744,11 @@
     },
     "nixpkgs-2111_23": {
       "locked": {
-        "lastModified": 1653319070,
-        "narHash": "sha256-Z3cv967iN6mXgxhq1cjOoPod23XgNttCWHXMnMZUq9E=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c813bbdc330b45fe922c642eb610902aecd5673",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9458,11 +8760,11 @@
     },
     "nixpkgs-2111_24": {
       "locked": {
-        "lastModified": 1644510859,
-        "narHash": "sha256-xjpVvL5ecbyi0vxtVl/Fh9bwGlMbw3S06zE5nUzFB8A=",
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d1d5d7e3679fec9d07f2eb804d9f9fdb98378d3",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
         "type": "github"
       },
       "original": {
@@ -9474,11 +8776,11 @@
     },
     "nixpkgs-2111_25": {
       "locked": {
-        "lastModified": 1656492155,
-        "narHash": "sha256-oKWpYhhgZ2Yt4BZHKSFwJSwOAoFawWxNiW0y7wpde+I=",
+        "lastModified": 1659375853,
+        "narHash": "sha256-aiMfO6U1w1u93vB+5qCHCQDZKgpJ7qs4GJOQvI3CN/4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a5ca644cc5e96336e7717aca871f01320c2df09",
+        "rev": "511f6a5c3248f9019a41e70c1891484de2bc906c",
         "type": "github"
       },
       "original": {
@@ -9504,13 +8806,77 @@
         "type": "github"
       }
     },
-    "nixpkgs-2111_3": {
+    "nixpkgs-2111_27": {
       "locked": {
-        "lastModified": 1652298859,
-        "narHash": "sha256-hcwRboK+NxMWUJh0fQ3VsocDcAHrYJ95FmPEHlddV0Y=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "051448e41537c3463ae776d46115d01afb6c498d",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_28": {
+      "locked": {
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_29": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_3": {
+      "locked": {
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_30": {
+      "locked": {
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
         "type": "github"
       },
       "original": {
@@ -9538,11 +8904,11 @@
     },
     "nixpkgs-2111_5": {
       "locked": {
-        "lastModified": 1653319070,
-        "narHash": "sha256-Z3cv967iN6mXgxhq1cjOoPod23XgNttCWHXMnMZUq9E=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c813bbdc330b45fe922c642eb610902aecd5673",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9570,11 +8936,11 @@
     },
     "nixpkgs-2111_7": {
       "locked": {
-        "lastModified": 1652364845,
-        "narHash": "sha256-1pG2GR+z7IrUVGcMoTsH6nJ+ACMvBplo/Pyw4SXJDIE=",
+        "lastModified": 1658346836,
+        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee80943d4d1160f460e3d719222212dbfbc6a193",
+        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
         "type": "github"
       },
       "original": {
@@ -9602,16 +8968,48 @@
     },
     "nixpkgs-2111_9": {
       "locked": {
-        "lastModified": 1658346836,
-        "narHash": "sha256-c9BZZbi0tqCQ4j6CMVDlsut3Q3ET1Fezf+qIslCfkhs=",
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1fe662eb26ffc2a036b37c4670392ade632c413",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1660033036,
+        "narHash": "sha256-GjwzXmdN5SVTT0RIZ11uDTQxaHLTLt9/AbBeIHNfidQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "490f6174c03132bf8f078d0f3a6e5890a47f9b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205_2": {
+      "locked": {
+        "lastModified": 1660033036,
+        "narHash": "sha256-GjwzXmdN5SVTT0RIZ11uDTQxaHLTLt9/AbBeIHNfidQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "490f6174c03132bf8f078d0f3a6e5890a47f9b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -9904,7 +9302,87 @@
         "type": "github"
       }
     },
+    "nixpkgs-latest_26": {
+      "locked": {
+        "lastModified": 1653918805,
+        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      }
+    },
+    "nixpkgs-latest_27": {
+      "locked": {
+        "lastModified": 1653918805,
+        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      }
+    },
+    "nixpkgs-latest_28": {
+      "locked": {
+        "lastModified": 1653918805,
+        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      }
+    },
+    "nixpkgs-latest_29": {
+      "locked": {
+        "lastModified": 1659622790,
+        "narHash": "sha256-fYelfx2ScXVprcivGPif+hi9cOZPt3/4wV5rC3AwZDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
+        "type": "github"
+      }
+    },
     "nixpkgs-latest_3": {
+      "locked": {
+        "lastModified": 1653918805,
+        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "type": "github"
+      }
+    },
+    "nixpkgs-latest_30": {
       "locked": {
         "lastModified": 1653918805,
         "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
@@ -10002,17 +9480,17 @@
     },
     "nixpkgs-latest_9": {
       "locked": {
-        "lastModified": 1653918805,
-        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "lastModified": 1659622790,
+        "narHash": "sha256-fYelfx2ScXVprcivGPif+hi9cOZPt3/4wV5rC3AwZDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "rev": "cf63df0364f67848083ff75bc8ac9b7ca7aa5a01",
         "type": "github"
       }
     },
@@ -10062,6 +9540,51 @@
       }
     },
     "nixpkgs-regression_12": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-regression_13": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-regression_14": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-regression_15": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -10246,11 +9769,11 @@
     },
     "nixpkgs-unstable_12": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
@@ -10261,6 +9784,38 @@
       }
     },
     "nixpkgs-unstable_13": {
+      "locked": {
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_14": {
+      "locked": {
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_15": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -10405,45 +9960,12 @@
       }
     },
     "nixpkgs_10": {
-      "flake": false,
       "locked": {
-        "lastModified": 1645493675,
-        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
-      "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
@@ -10451,7 +9973,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -10466,7 +9988,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -10482,7 +10004,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_15": {
+    "nixpkgs_13": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -10499,34 +10021,66 @@
         "type": "github"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_14": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_16": {
+      "locked": {
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_17": {
+      "flake": false,
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_18": {
@@ -10562,11 +10116,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
@@ -10593,6 +10147,20 @@
     },
     "nixpkgs_21": {
       "locked": {
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_22": {
+      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -10606,7 +10174,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_22": {
+    "nixpkgs_23": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -10622,7 +10190,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_23": {
+    "nixpkgs_24": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -10639,29 +10207,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_24": {
-      "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_25": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
@@ -10719,18 +10271,16 @@
     },
     "nixpkgs_29": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs_3": {
@@ -10750,35 +10300,21 @@
     },
     "nixpkgs_30": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
     "nixpkgs_31": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_32": {
-      "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
         "owner": "NixOS",
@@ -10789,50 +10325,34 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_33": {
-      "flake": false,
       "locked": {
-        "lastModified": 1645493675,
-        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_34": {
-      "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_35": {
-      "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
@@ -10840,7 +10360,21 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_36": {
+    "nixpkgs_34": {
+      "locked": {
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_35": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -10855,7 +10389,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_37": {
+    "nixpkgs_36": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -10871,7 +10405,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_38": {
+    "nixpkgs_37": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -10888,20 +10422,33 @@
         "type": "github"
       }
     },
-    "nixpkgs_39": {
+    "nixpkgs_38": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_39": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nixpkgs_4": {
@@ -10922,35 +10469,6 @@
     },
     "nixpkgs_40": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_41": {
-      "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_42": {
-      "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
         "owner": "NixOS",
@@ -10965,7 +10483,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_43": {
+    "nixpkgs_41": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -10982,68 +10500,52 @@
         "type": "github"
       }
     },
-    "nixpkgs_44": {
+    "nixpkgs_42": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_43": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_44": {
+      "locked": {
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_45": {
-      "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_46": {
-      "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_47": {
-      "locked": {
-        "lastModified": 1647297614,
-        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_48": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -11060,18 +10562,64 @@
         "type": "github"
       }
     },
-    "nixpkgs_49": {
+    "nixpkgs_46": {
       "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_47": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_48": {
+      "locked": {
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_49": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -11095,20 +10643,6 @@
     },
     "nixpkgs_50": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_51": {
-      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -11122,7 +10656,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_52": {
+    "nixpkgs_51": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -11138,7 +10672,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_53": {
+    "nixpkgs_52": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -11155,61 +10689,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_54": {
+    "nixpkgs_53": {
       "locked": {
-        "lastModified": 1650882267,
-        "narHash": "sha256-BFKiz8srATQIBuFEN2HgS2EHisK29EjZ/HV34wSr2lU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2ea2f7b6d0cb7ce0712f2aa80303cda08deb0de2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2ea2f7b6d0cb7ce0712f2aa80303cda08deb0de2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_55": {
-      "locked": {
-        "lastModified": 1647350163,
-        "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
-        "type": "github"
-      }
-    },
-    "nixpkgs_56": {
-      "locked": {
-        "lastModified": 1649456639,
-        "narHash": "sha256-rZCjaEAZgOtT9kYTBigksof64SqKAXOuoHhlzHvfl0E=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c48167590e3258daac6ab12a41bc2b7341e9b2ec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c48167590e3258daac6ab12a41bc2b7341e9b2ec",
-        "type": "github"
-      }
-    },
-    "nixpkgs_57": {
-      "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
         "type": "github"
       },
       "original": {
@@ -11217,56 +10703,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_58": {
-      "locked": {
-        "lastModified": 1647297614,
-        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_59": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1628785280,
-        "narHash": "sha256-2B5eMrEr6O8ff2aQNeVxTB+9WrGE80OB4+oM6T7fOcc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6525bbc06a39f26750ad8ee0d40000ddfdc24acb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1652885393,
-        "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48037fd90426e44e4bf03e6479e88a11453b9b66",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_60": {
+    "nixpkgs_54": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -11281,7 +10718,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_61": {
+    "nixpkgs_55": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -11297,7 +10734,83 @@
         "type": "github"
       }
     },
-    "nixpkgs_62": {
+    "nixpkgs_56": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_57": {
+      "locked": {
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_58": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_59": {
+      "locked": {
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1657292830,
+        "narHash": "sha256-ldfVSTveWceDCmW6gf3B4kR6vwmz/XS80y5wsLLHFJU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "334ec8b503c3981e37a04b817a70e8d026ea9e84",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_60": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -11316,20 +10829,6 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1653117584,
-        "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f4dfed73ee886b115a99e5b85fdfbeb683290d83",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -11343,7 +10842,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -11355,6 +10854,23 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -11428,6 +10944,40 @@
       }
     },
     "old-ghc-nix_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_15": {
       "flake": false,
       "locked": {
         "lastModified": 1631092763,
@@ -11580,221 +11130,19 @@
         "type": "github"
       }
     },
-    "pandoc-link-context": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650932770,
-        "narHash": "sha256-/WzE4O23B1OcL3WF8Saz5TRQj0tGH7FtbgRLRson2Mc=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "85bd204339aafd309b8a3dd99ebffa6a50776cb6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pandoc-link-context_9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653170888,
-        "narHash": "sha256-bA/Oj2pt3H2b4lqWqVBYo3Qhvhd01r4vM39+vLuPMtA=",
-        "owner": "srid",
-        "repo": "pandoc-link-context",
-        "rev": "c3a3de34b291b2bfec04387af65e0cc0822373c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "pandoc-link-context",
-        "type": "github"
-      }
-    },
-    "pathtree": {
-      "inputs": {
-        "flake-compat": "flake-compat_22",
-        "flake-utils": "flake-utils_34",
-        "nixpkgs": "nixpkgs_55"
-      },
-      "locked": {
-        "lastModified": 1649011952,
-        "narHash": "sha256-RuNIoPXx0xy5TZ81JH33V8EqXWX5erv8gepM0Aaeat8=",
-        "owner": "srid",
-        "repo": "pathtree",
-        "rev": "d60f22b356f79663aca3f5fde9f23bb4a1412963",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "pathtree",
-        "type": "github"
-      }
-    },
     "plutarch": {
       "inputs": {
         "cardano-base": "cardano-base",
         "cardano-crypto": "cardano-crypto",
         "cardano-prelude": "cardano-prelude",
-        "emanote": "emanote",
+        "emanote": [
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat",
-        "haskell-language-server": "haskell-language-server_2",
+        "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage",
         "hercules-ci-effects": "hercules-ci-effects",
@@ -11811,29 +11159,47 @@
         "secp256k1-haskell": "secp256k1-haskell"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
     "plutarch-context-builder": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_4",
+        "haskell-language-server": [
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "liqwid-plutarch-extra",
           "plutarch-context-builder",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_3",
         "nixpkgs": [
           "liqwid-plutarch-extra",
           "plutarch-context-builder",
@@ -11845,15 +11211,15 @@
         "plutarch": "plutarch_2"
       },
       "locked": {
-        "lastModified": 1658268102,
-        "narHash": "sha256-RE8vhqLY9wXfJHt7933HSaezO3/eP/YmJVdqfbDbKN0=",
-        "owner": "liqwid-labs",
+        "lastModified": 1659452596,
+        "narHash": "sha256-j0StZAogDVbpjzBXsWzlAO4JPp2pafMnG5ndgMyeuwU=",
+        "owner": "Liqwid-Labs",
         "repo": "plutarch-context-builder",
-        "rev": "1f2df0a09a3c60ee398c87723e9443d1c4c45102",
+        "rev": "7dfa384bbf5427412ba78ef48ddd86ca251fdb18",
         "type": "github"
       },
       "original": {
-        "owner": "liqwid-labs",
+        "owner": "Liqwid-Labs",
         "ref": "staging",
         "repo": "plutarch-context-builder",
         "type": "github"
@@ -11861,12 +11227,27 @@
     },
     "plutarch-context-builder_2": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_15",
+        "haskell-language-server": [
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-context-builder",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-context-builder",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_6",
         "nixpkgs": [
           "plutarch-context-builder",
           "plutarch",
@@ -11877,29 +11258,104 @@
         "plutarch": "plutarch_6"
       },
       "locked": {
-        "lastModified": 1658368717,
-        "narHash": "sha256-GAneUtaxaJSZLNkIGOTByx/Auuq1g3MhzBhTiqZ13+s=",
+        "lastModified": 1659452596,
+        "narHash": "sha256-j0StZAogDVbpjzBXsWzlAO4JPp2pafMnG5ndgMyeuwU=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-context-builder",
-        "rev": "2a2ca72ff310788e531cbbe379ef7b0c4cb42dc9",
+        "rev": "7dfa384bbf5427412ba78ef48ddd86ca251fdb18",
         "type": "github"
       },
       "original": {
         "owner": "Liqwid-Labs",
-        "ref": "2a2ca72ff310788e531cbbe379ef7b0c4cb42dc9",
+        "ref": "plutus-v1",
+        "repo": "plutarch-context-builder",
+        "type": "github"
+      }
+    },
+    "plutarch-context-builder_3": {
+      "inputs": {
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-language-server"
+        ],
+        "haskell-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix"
+        ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_11",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "nixpkgs"
+        ],
+        "nixpkgs-2111": "nixpkgs-2111_19",
+        "nixpkgs-latest": "nixpkgs-latest_19",
+        "plutarch": "plutarch_10"
+      },
+      "locked": {
+        "lastModified": 1659452596,
+        "narHash": "sha256-j0StZAogDVbpjzBXsWzlAO4JPp2pafMnG5ndgMyeuwU=",
+        "owner": "Liqwid-Labs",
+        "repo": "plutarch-context-builder",
+        "rev": "7dfa384bbf5427412ba78ef48ddd86ca251fdb18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Liqwid-Labs",
+        "ref": "staging",
         "repo": "plutarch-context-builder",
         "type": "github"
       }
     },
     "plutarch-numeric": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_7",
+        "haskell-language-server": [
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "liqwid-plutarch-extra",
           "plutarch-numeric",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_4",
         "nixpkgs": [
           "liqwid-plutarch-extra",
           "plutarch-numeric",
@@ -11911,27 +11367,43 @@
         "plutarch": "plutarch_3"
       },
       "locked": {
-        "lastModified": 1655733533,
-        "narHash": "sha256-HRSJUEQYYwr0HvYn6GwLmyYY7TXwZcYPAW0U8t6nmok=",
+        "lastModified": 1659450964,
+        "narHash": "sha256-jkxeMZ5ZjEl94MG5jWC+ogeh8m5sCpR7FX2Srtedvc4=",
         "owner": "liqwid-labs",
         "repo": "plutarch-numeric",
-        "rev": "ce2d39dc366d9453b0f5df328bbb78f11e3b2ed6",
+        "rev": "65a1a5dec3836cf4e3c793bf780a4ee84b0a9331",
         "type": "github"
       },
       "original": {
         "owner": "liqwid-labs",
+        "ref": "main",
         "repo": "plutarch-numeric",
         "type": "github"
       }
     },
     "plutarch-numeric_2": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_18",
+        "haskell-language-server": [
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-numeric",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-numeric",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_7",
         "nixpkgs": [
           "plutarch-numeric",
           "plutarch",
@@ -11942,11 +11414,11 @@
         "plutarch": "plutarch_7"
       },
       "locked": {
-        "lastModified": 1656613288,
-        "narHash": "sha256-h2rM+Ng/wyWwqRY41NbxPHBJLIfcqsjeCItYK7iQvR8=",
+        "lastModified": 1659450964,
+        "narHash": "sha256-jkxeMZ5ZjEl94MG5jWC+ogeh8m5sCpR7FX2Srtedvc4=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-numeric",
-        "rev": "da44b2af83f28276cf7466586a8e66291f104663",
+        "rev": "65a1a5dec3836cf4e3c793bf780a4ee84b0a9331",
         "type": "github"
       },
       "original": {
@@ -11958,29 +11430,104 @@
     },
     "plutarch-numeric_3": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_33",
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-language-server"
+        ],
+        "haskell-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix"
+        ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_12",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "nixpkgs"
+        ],
+        "nixpkgs-2111": "nixpkgs-2111_21",
+        "nixpkgs-latest": "nixpkgs-latest_21",
+        "plutarch": "plutarch_11"
+      },
+      "locked": {
+        "lastModified": 1659450964,
+        "narHash": "sha256-jkxeMZ5ZjEl94MG5jWC+ogeh8m5sCpR7FX2Srtedvc4=",
+        "owner": "liqwid-labs",
+        "repo": "plutarch-numeric",
+        "rev": "65a1a5dec3836cf4e3c793bf780a4ee84b0a9331",
+        "type": "github"
+      },
+      "original": {
+        "owner": "liqwid-labs",
+        "ref": "main",
+        "repo": "plutarch-numeric",
+        "type": "github"
+      }
+    },
+    "plutarch-numeric_4": {
+      "inputs": {
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-safe-money",
           "plutarch-numeric",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_14",
         "nixpkgs": [
           "plutarch-safe-money",
           "plutarch-numeric",
           "plutarch",
           "nixpkgs"
         ],
-        "nixpkgs-2111": "nixpkgs-2111_23",
-        "nixpkgs-latest": "nixpkgs-latest_23",
-        "plutarch": "plutarch_12"
+        "nixpkgs-2111": "nixpkgs-2111_27",
+        "nixpkgs-latest": "nixpkgs-latest_27",
+        "plutarch": "plutarch_14"
       },
       "locked": {
-        "lastModified": 1654950823,
-        "narHash": "sha256-fq6Iyk1ygNs4sTS55jLjx0hWFAFQNKXBGrVHuzRXFls=",
+        "lastModified": 1659450964,
+        "narHash": "sha256-jkxeMZ5ZjEl94MG5jWC+ogeh8m5sCpR7FX2Srtedvc4=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-numeric",
-        "rev": "11fdf47fdcbf19d51ed587b0b67618152098f442",
+        "rev": "65a1a5dec3836cf4e3c793bf780a4ee84b0a9331",
         "type": "github"
       },
       "original": {
@@ -11992,13 +11539,31 @@
     },
     "plutarch-quickcheck": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_10",
+        "haskell-language-server": [
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "liqwid-plutarch-extra",
           "plutarch-quickcheck",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_5",
         "nixpkgs": [
           "liqwid-plutarch-extra",
           "plutarch-quickcheck",
@@ -12010,28 +11575,43 @@
         "plutarch": "plutarch_4"
       },
       "locked": {
-        "lastModified": 1655113586,
-        "narHash": "sha256-hv9tzB3IGvga6/SBDnk16S3Sfp03tvtkWd8COW0It30=",
+        "lastModified": 1659450065,
+        "narHash": "sha256-x6B9sjrZaTite4TSLLyOWfmG3JJbOZuGUNMDZ1f4qhk=",
         "owner": "liqwid-labs",
         "repo": "plutarch-quickcheck",
-        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
+        "rev": "2c5b77f1a622ce68d80a09b286eb0ac85527ff26",
         "type": "github"
       },
       "original": {
         "owner": "liqwid-labs",
+        "ref": "staging",
         "repo": "plutarch-quickcheck",
-        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
         "type": "github"
       }
     },
     "plutarch-quickcheck_2": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_21",
+        "haskell-language-server": [
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-quickcheck",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-quickcheck",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_8",
         "nixpkgs": [
           "plutarch-quickcheck",
           "plutarch",
@@ -12042,11 +11622,11 @@
         "plutarch": "plutarch_8"
       },
       "locked": {
-        "lastModified": 1655307888,
-        "narHash": "sha256-hv9tzB3IGvga6/SBDnk16S3Sfp03tvtkWd8COW0It30=",
+        "lastModified": 1659450065,
+        "narHash": "sha256-x6B9sjrZaTite4TSLLyOWfmG3JJbOZuGUNMDZ1f4qhk=",
         "owner": "liqwid-labs",
         "repo": "plutarch-quickcheck",
-        "rev": "541c57675eefc2ecd0fb6c6477d0b7fb8900b5fc",
+        "rev": "2c5b77f1a622ce68d80a09b286eb0ac85527ff26",
         "type": "github"
       },
       "original": {
@@ -12058,7 +11638,13 @@
     },
     "plutarch-quickcheck_3": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_28",
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
@@ -12066,6 +11652,21 @@
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_13",
         "nixpkgs": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
@@ -12073,81 +11674,112 @@
           "plutarch",
           "nixpkgs"
         ],
-        "nixpkgs-2111": "nixpkgs-2111_19",
-        "nixpkgs-latest": "nixpkgs-latest_19",
-        "plutarch": "plutarch_10"
+        "nixpkgs-2111": "nixpkgs-2111_23",
+        "nixpkgs-latest": "nixpkgs-latest_23",
+        "plutarch": "plutarch_12"
       },
       "locked": {
-        "lastModified": 1655113586,
-        "narHash": "sha256-hv9tzB3IGvga6/SBDnk16S3Sfp03tvtkWd8COW0It30=",
+        "lastModified": 1659450065,
+        "narHash": "sha256-x6B9sjrZaTite4TSLLyOWfmG3JJbOZuGUNMDZ1f4qhk=",
         "owner": "liqwid-labs",
         "repo": "plutarch-quickcheck",
-        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
+        "rev": "2c5b77f1a622ce68d80a09b286eb0ac85527ff26",
         "type": "github"
       },
       "original": {
         "owner": "liqwid-labs",
+        "ref": "staging",
         "repo": "plutarch-quickcheck",
-        "rev": "a560e12b4809c0f292c96e81189e1b2cf2e7f7eb",
         "type": "github"
       }
     },
     "plutarch-safe-money": {
       "inputs": {
-        "haskell-language-server": "haskell-language-server_24",
+        "haskell-language-server": [
+          "plutarch-safe-money",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-safe-money",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-safe-money",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-safe-money",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_9",
         "liqwid-plutarch-extra": "liqwid-plutarch-extra_2",
         "nixpkgs": [
           "plutarch-safe-money",
           "plutarch",
           "nixpkgs"
         ],
-        "nixpkgs-2111": "nixpkgs-2111_21",
-        "nixpkgs-latest": "nixpkgs-latest_21",
-        "plutarch": "plutarch_11",
-        "plutarch-numeric": "plutarch-numeric_3"
+        "nixpkgs-2111": "nixpkgs-2111_25",
+        "nixpkgs-latest": "nixpkgs-latest_25",
+        "plutarch": "plutarch_13",
+        "plutarch-numeric": "plutarch-numeric_4"
       },
       "locked": {
-        "lastModified": 1655471113,
-        "narHash": "sha256-6z17r2rs2M+Gv7MJep6+zP2bq6G5Id4XDhInpU5RulM=",
+        "lastModified": 1659604619,
+        "narHash": "sha256-pqjjb/J773z2cE7bBsszxj2QnefewJlIIe1NbDeKrLw=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-safe-money",
-        "rev": "9f968b80189c7e4b335527cd5b103dc26952f667",
+        "rev": "6e4f2112a36b2937fc2f3f7143abb4f4c42e7428",
         "type": "github"
       },
       "original": {
         "owner": "Liqwid-Labs",
+        "ref": "main",
         "repo": "plutarch-safe-money",
-        "rev": "9f968b80189c7e4b335527cd5b103dc26952f667",
         "type": "github"
       }
     },
     "plutarch-script-export": {
       "inputs": {
+        "haskell-language-server": [
+          "plutarch-script-export",
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch-script-export",
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch-script-export",
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch-script-export",
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix_15",
         "nixpkgs": [
           "plutarch-script-export",
           "plutarch",
           "nixpkgs"
         ],
-        "nixpkgs-2111": "nixpkgs-2111_25",
-        "nixpkgs-latest": "nixpkgs-latest_24",
-        "plutarch": "plutarch_13"
+        "nixpkgs-2111": "nixpkgs-2111_29",
+        "nixpkgs-latest": "nixpkgs-latest_29",
+        "plutarch": "plutarch_15"
       },
       "locked": {
-        "lastModified": 1657374093,
-        "narHash": "sha256-96K/mcNI8lNto+gLSOhnGADQYfWrp3+PrZYKoNzSS1A=",
+        "lastModified": 1660213721,
+        "narHash": "sha256-YkDefu3XK1FelMFCgf3jOkzc3ugCS1DXUgr9rZoukPw=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-script-export",
-        "rev": "85c3b8a2ef856e7c18d3227e33fc2dd7bebf3bc1",
+        "rev": "4d8f6af19d727c46fc8d746b1f6d3e356196610f",
         "type": "github"
       },
       "original": {
@@ -12162,9 +11794,16 @@
         "cardano-base": "cardano-base_10",
         "cardano-crypto": "cardano-crypto_10",
         "cardano-prelude": "cardano-prelude_10",
-        "emanote": "emanote_9",
+        "emanote": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_10",
-        "haskell-language-server": "haskell-language-server_29",
+        "haskell-language-server": "haskell-language-server_19",
         "haskell-nix": "haskell-nix_19",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_10",
         "hercules-ci-effects": "hercules-ci-effects_10",
@@ -12172,7 +11811,7 @@
         "nixpkgs": [
           "plutarch-safe-money",
           "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
+          "plutarch-context-builder",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -12183,17 +11822,17 @@
         "secp256k1-haskell": "secp256k1-haskell_10"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12202,15 +11841,24 @@
         "cardano-base": "cardano-base_11",
         "cardano-crypto": "cardano-crypto_11",
         "cardano-prelude": "cardano-prelude_11",
-        "emanote": "emanote_10",
+        "emanote": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_11",
-        "haskell-language-server": "haskell-language-server_31",
+        "haskell-language-server": "haskell-language-server_21",
         "haskell-nix": "haskell-nix_21",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_11",
         "hercules-ci-effects": "hercules-ci-effects_11",
         "iohk-nix": "iohk-nix_21",
         "nixpkgs": [
           "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -12221,62 +11869,64 @@
         "secp256k1-haskell": "secp256k1-haskell_11"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
     "plutarch_12": {
       "inputs": {
-        "Shrinker": "Shrinker",
         "cardano-base": "cardano-base_12",
         "cardano-crypto": "cardano-crypto_12",
         "cardano-prelude": "cardano-prelude_12",
-        "cryptonite": "cryptonite",
-        "emanote": "emanote_11",
-        "flat": "flat_12",
-        "foundation": "foundation",
-        "haskell-language-server": "haskell-language-server_34",
-        "haskell-nix": "haskell-nix_23",
-        "hercules-ci-effects": "hercules-ci-effects_12",
-        "hs-memory": "hs-memory",
-        "hspec": "hspec",
-        "hspec-golden": "hspec-golden",
-        "hspec-hedgehog": "hspec-hedgehog",
-        "iohk-nix": "iohk-nix_23",
-        "nixpkgs": [
+        "emanote": [
           "plutarch-safe-money",
-          "plutarch-numeric",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
+        "flat": "flat_12",
+        "haskell-language-server": "haskell-language-server_23",
+        "haskell-nix": "haskell-nix_23",
+        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_12",
+        "hercules-ci-effects": "hercules-ci-effects_12",
+        "iohk-nix": "iohk-nix_23",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-latest": "nixpkgs-latest_24",
         "plutus": "plutus_12",
         "protolude": "protolude_12",
-        "sized-functors": "sized-functors",
-        "th-extras": "th-extras"
+        "secp256k1-haskell": "secp256k1-haskell_12"
       },
       "locked": {
-        "lastModified": 1652353304,
-        "narHash": "sha256-DeSwiDyJeI9had5OCxLiGtYeDl07Vic0cR8RETBLY9k=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "ae2059f11f24d47bedeaa18749d01711cddab0bc",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12286,40 +11936,128 @@
         "cardano-crypto": "cardano-crypto_13",
         "cardano-prelude": "cardano-prelude_13",
         "emanote": [
-          "plutarch-script-export",
+          "plutarch-safe-money",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
         "flat": "flat_13",
-        "haskell-language-server": "haskell-language-server_36",
+        "haskell-language-server": "haskell-language-server_25",
         "haskell-nix": "haskell-nix_25",
-        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_12",
+        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_13",
         "hercules-ci-effects": "hercules-ci-effects_13",
         "iohk-nix": "iohk-nix_25",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-latest": "nixpkgs-latest_26",
+        "plutus": "plutus_13",
+        "protolude": "protolude_13",
+        "secp256k1-haskell": "secp256k1-haskell_13"
+      },
+      "locked": {
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Plutonomicon",
+        "ref": "staging",
+        "repo": "plutarch-plutus",
+        "type": "github"
+      }
+    },
+    "plutarch_14": {
+      "inputs": {
+        "cardano-base": "cardano-base_14",
+        "cardano-crypto": "cardano-crypto_14",
+        "cardano-prelude": "cardano-prelude_14",
+        "emanote": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "flat": "flat_14",
+        "haskell-language-server": "haskell-language-server_27",
+        "haskell-nix": "haskell-nix_27",
+        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_14",
+        "hercules-ci-effects": "hercules-ci-effects_14",
+        "iohk-nix": "iohk-nix_27",
+        "nixpkgs": [
+          "plutarch-safe-money",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-latest": "nixpkgs-latest_28",
+        "plutus": "plutus_14",
+        "protolude": "protolude_14",
+        "secp256k1-haskell": "secp256k1-haskell_14"
+      },
+      "locked": {
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Plutonomicon",
+        "ref": "staging",
+        "repo": "plutarch-plutus",
+        "type": "github"
+      }
+    },
+    "plutarch_15": {
+      "inputs": {
+        "cardano-base": "cardano-base_15",
+        "cardano-crypto": "cardano-crypto_15",
+        "cardano-prelude": "cardano-prelude_15",
+        "emanote": [
+          "plutarch-script-export",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "flat": "flat_15",
+        "haskell-language-server": "haskell-language-server_29",
+        "haskell-nix": "haskell-nix_29",
+        "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_15",
+        "hercules-ci-effects": "hercules-ci-effects_15",
+        "iohk-nix": "iohk-nix_29",
         "nixpkgs": [
           "plutarch-script-export",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-latest": "nixpkgs-latest_25",
-        "plutus": "plutus_13",
-        "protolude": "protolude_13",
-        "secp256k1-haskell": "secp256k1-haskell_12"
+        "nixpkgs-latest": "nixpkgs-latest_30",
+        "plutus": "plutus_15",
+        "protolude": "protolude_15",
+        "secp256k1-haskell": "secp256k1-haskell_15"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "liqwid-labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "liqwid-labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "owner": "Plutonomicon",
+        "ref": "staging",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12328,9 +12066,15 @@
         "cardano-base": "cardano-base_2",
         "cardano-crypto": "cardano-crypto_2",
         "cardano-prelude": "cardano-prelude_2",
-        "emanote": "emanote_2",
+        "emanote": [
+          "liqwid-plutarch-extra",
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_2",
-        "haskell-language-server": "haskell-language-server_5",
+        "haskell-language-server": "haskell-language-server_3",
         "haskell-nix": "haskell-nix_3",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_2",
         "hercules-ci-effects": "hercules-ci-effects_2",
@@ -12348,17 +12092,17 @@
         "secp256k1-haskell": "secp256k1-haskell_2"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12367,9 +12111,15 @@
         "cardano-base": "cardano-base_3",
         "cardano-crypto": "cardano-crypto_3",
         "cardano-prelude": "cardano-prelude_3",
-        "emanote": "emanote_3",
+        "emanote": [
+          "liqwid-plutarch-extra",
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_3",
-        "haskell-language-server": "haskell-language-server_8",
+        "haskell-language-server": "haskell-language-server_5",
         "haskell-nix": "haskell-nix_5",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_3",
         "hercules-ci-effects": "hercules-ci-effects_3",
@@ -12387,17 +12137,17 @@
         "secp256k1-haskell": "secp256k1-haskell_3"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12406,9 +12156,15 @@
         "cardano-base": "cardano-base_4",
         "cardano-crypto": "cardano-crypto_4",
         "cardano-prelude": "cardano-prelude_4",
-        "emanote": "emanote_4",
+        "emanote": [
+          "liqwid-plutarch-extra",
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_4",
-        "haskell-language-server": "haskell-language-server_11",
+        "haskell-language-server": "haskell-language-server_7",
         "haskell-nix": "haskell-nix_7",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_4",
         "hercules-ci-effects": "hercules-ci-effects_4",
@@ -12426,17 +12182,17 @@
         "secp256k1-haskell": "secp256k1-haskell_4"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12451,7 +12207,7 @@
           "nixpkgs-unstable"
         ],
         "flat": "flat_5",
-        "haskell-language-server": "haskell-language-server_13",
+        "haskell-language-server": "haskell-language-server_9",
         "haskell-nix": "haskell-nix_9",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_5",
         "hercules-ci-effects": "hercules-ci-effects_5",
@@ -12467,17 +12223,17 @@
         "secp256k1-haskell": "secp256k1-haskell_5"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "liqwid-labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "liqwid-labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "owner": "Plutonomicon",
+        "ref": "staging",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12486,9 +12242,14 @@
         "cardano-base": "cardano-base_6",
         "cardano-crypto": "cardano-crypto_6",
         "cardano-prelude": "cardano-prelude_6",
-        "emanote": "emanote_5",
+        "emanote": [
+          "plutarch-context-builder",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_6",
-        "haskell-language-server": "haskell-language-server_16",
+        "haskell-language-server": "haskell-language-server_11",
         "haskell-nix": "haskell-nix_11",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_6",
         "hercules-ci-effects": "hercules-ci-effects_6",
@@ -12505,17 +12266,17 @@
         "secp256k1-haskell": "secp256k1-haskell_6"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12524,9 +12285,14 @@
         "cardano-base": "cardano-base_7",
         "cardano-crypto": "cardano-crypto_7",
         "cardano-prelude": "cardano-prelude_7",
-        "emanote": "emanote_6",
+        "emanote": [
+          "plutarch-numeric",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_7",
-        "haskell-language-server": "haskell-language-server_19",
+        "haskell-language-server": "haskell-language-server_13",
         "haskell-nix": "haskell-nix_13",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_7",
         "hercules-ci-effects": "hercules-ci-effects_7",
@@ -12543,17 +12309,17 @@
         "secp256k1-haskell": "secp256k1-haskell_7"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12562,9 +12328,14 @@
         "cardano-base": "cardano-base_8",
         "cardano-crypto": "cardano-crypto_8",
         "cardano-prelude": "cardano-prelude_8",
-        "emanote": "emanote_7",
+        "emanote": [
+          "plutarch-quickcheck",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_8",
-        "haskell-language-server": "haskell-language-server_22",
+        "haskell-language-server": "haskell-language-server_15",
         "haskell-nix": "haskell-nix_15",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_8",
         "hercules-ci-effects": "hercules-ci-effects_8",
@@ -12581,17 +12352,17 @@
         "secp256k1-haskell": "secp256k1-haskell_8"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12600,9 +12371,15 @@
         "cardano-base": "cardano-base_9",
         "cardano-crypto": "cardano-crypto_9",
         "cardano-prelude": "cardano-prelude_9",
-        "emanote": "emanote_8",
+        "emanote": [
+          "plutarch-safe-money",
+          "liqwid-plutarch-extra",
+          "plutarch",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
         "flat": "flat_9",
-        "haskell-language-server": "haskell-language-server_26",
+        "haskell-language-server": "haskell-language-server_17",
         "haskell-nix": "haskell-nix_17",
         "haskell-nix-extra-hackage": "haskell-nix-extra-hackage_9",
         "hercules-ci-effects": "hercules-ci-effects_9",
@@ -12620,17 +12397,17 @@
         "secp256k1-haskell": "secp256k1-haskell_9"
       },
       "locked": {
-        "lastModified": 1654108284,
-        "narHash": "sha256-VD0zX4pFrJJaaUO7uJgioZGg1moe1Fy8nAb5j2mV/Qc=",
-        "owner": "Liqwid-Labs",
-        "repo": "plutarch",
-        "rev": "e7ef565645146e26e75ec29fe97122a74e52c6b7",
+        "lastModified": 1659381657,
+        "narHash": "sha256-W0EWY0DV2idbIeqtJnShVHQ83exME8TK2GYQGbVpz8A=",
+        "owner": "Plutonomicon",
+        "repo": "plutarch-plutus",
+        "rev": "45b7c77a9ee9bd6c7dc25ddebcc3d12c58c4c3a2",
         "type": "github"
       },
       "original": {
-        "owner": "Liqwid-Labs",
+        "owner": "Plutonomicon",
         "ref": "staging",
-        "repo": "plutarch",
+        "repo": "plutarch-plutus",
         "type": "github"
       }
     },
@@ -12639,7 +12416,7 @@
         "cardano-repo-tool": "cardano-repo-tool",
         "gitignore-nix": "gitignore-nix",
         "hackage-nix": "hackage-nix",
-        "haskell-language-server": "haskell-language-server_3",
+        "haskell-language-server": "haskell-language-server_2",
         "haskell-nix": "haskell-nix_2",
         "iohk-nix": "iohk-nix_2",
         "nixpkgs": "nixpkgs_5",
@@ -12647,11 +12424,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12665,19 +12442,19 @@
         "cardano-repo-tool": "cardano-repo-tool_10",
         "gitignore-nix": "gitignore-nix_10",
         "hackage-nix": "hackage-nix_10",
-        "haskell-language-server": "haskell-language-server_30",
+        "haskell-language-server": "haskell-language-server_20",
         "haskell-nix": "haskell-nix_20",
         "iohk-nix": "iohk-nix_20",
-        "nixpkgs": "nixpkgs_48",
+        "nixpkgs": "nixpkgs_41",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_10",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_10"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12691,19 +12468,19 @@
         "cardano-repo-tool": "cardano-repo-tool_11",
         "gitignore-nix": "gitignore-nix_11",
         "hackage-nix": "hackage-nix_11",
-        "haskell-language-server": "haskell-language-server_32",
+        "haskell-language-server": "haskell-language-server_22",
         "haskell-nix": "haskell-nix_22",
         "iohk-nix": "iohk-nix_22",
-        "nixpkgs": "nixpkgs_53",
+        "nixpkgs": "nixpkgs_45",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_11",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_11"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12717,25 +12494,23 @@
         "cardano-repo-tool": "cardano-repo-tool_12",
         "gitignore-nix": "gitignore-nix_12",
         "hackage-nix": "hackage-nix_12",
-        "haskell-language-server": "haskell-language-server_35",
+        "haskell-language-server": "haskell-language-server_24",
         "haskell-nix": "haskell-nix_24",
         "iohk-nix": "iohk-nix_24",
-        "nixpkgs": "nixpkgs_59",
+        "nixpkgs": "nixpkgs_49",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_12",
-        "sphinxcontrib-haddock": "sphinxcontrib-haddock_12",
-        "stackage-nix": "stackage-nix"
+        "sphinxcontrib-haddock": "sphinxcontrib-haddock_12"
       },
       "locked": {
-        "lastModified": 1645203653,
-        "narHash": "sha256-HAi60mSkyMXzu1Wg3h6KdYZg+ufNMvX6obfcLo0ArL0=",
-        "owner": "L-as",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
+        "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "5ec17953aae3ac9546f6d923201eb1dbb4e058bb",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
-        "owner": "L-as",
-        "ref": "ghc9",
+        "owner": "input-output-hk",
         "repo": "plutus",
         "type": "github"
       }
@@ -12745,19 +12520,71 @@
         "cardano-repo-tool": "cardano-repo-tool_13",
         "gitignore-nix": "gitignore-nix_13",
         "hackage-nix": "hackage-nix_13",
-        "haskell-language-server": "haskell-language-server_37",
+        "haskell-language-server": "haskell-language-server_26",
         "haskell-nix": "haskell-nix_26",
         "iohk-nix": "iohk-nix_26",
-        "nixpkgs": "nixpkgs_62",
+        "nixpkgs": "nixpkgs_52",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_13",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_13"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "type": "github"
+      }
+    },
+    "plutus_14": {
+      "inputs": {
+        "cardano-repo-tool": "cardano-repo-tool_14",
+        "gitignore-nix": "gitignore-nix_14",
+        "hackage-nix": "hackage-nix_14",
+        "haskell-language-server": "haskell-language-server_28",
+        "haskell-nix": "haskell-nix_28",
+        "iohk-nix": "iohk-nix_28",
+        "nixpkgs": "nixpkgs_56",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix_14",
+        "sphinxcontrib-haddock": "sphinxcontrib-haddock_14"
+      },
+      "locked": {
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "type": "github"
+      }
+    },
+    "plutus_15": {
+      "inputs": {
+        "cardano-repo-tool": "cardano-repo-tool_15",
+        "gitignore-nix": "gitignore-nix_15",
+        "hackage-nix": "hackage-nix_15",
+        "haskell-language-server": "haskell-language-server_30",
+        "haskell-nix": "haskell-nix_30",
+        "iohk-nix": "iohk-nix_30",
+        "nixpkgs": "nixpkgs_60",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix_15",
+        "sphinxcontrib-haddock": "sphinxcontrib-haddock_15"
+      },
+      "locked": {
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
+        "owner": "input-output-hk",
+        "repo": "plutus",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12771,19 +12598,19 @@
         "cardano-repo-tool": "cardano-repo-tool_2",
         "gitignore-nix": "gitignore-nix_2",
         "hackage-nix": "hackage-nix_2",
-        "haskell-language-server": "haskell-language-server_6",
+        "haskell-language-server": "haskell-language-server_4",
         "haskell-nix": "haskell-nix_4",
         "iohk-nix": "iohk-nix_4",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_9",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_2"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12797,19 +12624,19 @@
         "cardano-repo-tool": "cardano-repo-tool_3",
         "gitignore-nix": "gitignore-nix_3",
         "hackage-nix": "hackage-nix_3",
-        "haskell-language-server": "haskell-language-server_9",
+        "haskell-language-server": "haskell-language-server_6",
         "haskell-nix": "haskell-nix_6",
         "iohk-nix": "iohk-nix_6",
-        "nixpkgs": "nixpkgs_15",
+        "nixpkgs": "nixpkgs_13",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_3",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12823,19 +12650,19 @@
         "cardano-repo-tool": "cardano-repo-tool_4",
         "gitignore-nix": "gitignore-nix_4",
         "hackage-nix": "hackage-nix_4",
-        "haskell-language-server": "haskell-language-server_12",
+        "haskell-language-server": "haskell-language-server_8",
         "haskell-nix": "haskell-nix_8",
         "iohk-nix": "iohk-nix_8",
-        "nixpkgs": "nixpkgs_20",
+        "nixpkgs": "nixpkgs_17",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_4"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12849,19 +12676,19 @@
         "cardano-repo-tool": "cardano-repo-tool_5",
         "gitignore-nix": "gitignore-nix_5",
         "hackage-nix": "hackage-nix_5",
-        "haskell-language-server": "haskell-language-server_14",
+        "haskell-language-server": "haskell-language-server_10",
         "haskell-nix": "haskell-nix_10",
         "iohk-nix": "iohk-nix_10",
-        "nixpkgs": "nixpkgs_23",
+        "nixpkgs": "nixpkgs_20",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_5",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_5"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12875,19 +12702,19 @@
         "cardano-repo-tool": "cardano-repo-tool_6",
         "gitignore-nix": "gitignore-nix_6",
         "hackage-nix": "hackage-nix_6",
-        "haskell-language-server": "haskell-language-server_17",
+        "haskell-language-server": "haskell-language-server_12",
         "haskell-nix": "haskell-nix_12",
         "iohk-nix": "iohk-nix_12",
-        "nixpkgs": "nixpkgs_28",
+        "nixpkgs": "nixpkgs_24",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_6",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_6"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12901,19 +12728,19 @@
         "cardano-repo-tool": "cardano-repo-tool_7",
         "gitignore-nix": "gitignore-nix_7",
         "hackage-nix": "hackage-nix_7",
-        "haskell-language-server": "haskell-language-server_20",
+        "haskell-language-server": "haskell-language-server_14",
         "haskell-nix": "haskell-nix_14",
         "iohk-nix": "iohk-nix_14",
-        "nixpkgs": "nixpkgs_33",
+        "nixpkgs": "nixpkgs_28",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_7",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_7"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12927,19 +12754,19 @@
         "cardano-repo-tool": "cardano-repo-tool_8",
         "gitignore-nix": "gitignore-nix_8",
         "hackage-nix": "hackage-nix_8",
-        "haskell-language-server": "haskell-language-server_23",
+        "haskell-language-server": "haskell-language-server_16",
         "haskell-nix": "haskell-nix_16",
         "iohk-nix": "iohk-nix_16",
-        "nixpkgs": "nixpkgs_38",
+        "nixpkgs": "nixpkgs_32",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_8",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_8"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -12953,19 +12780,19 @@
         "cardano-repo-tool": "cardano-repo-tool_9",
         "gitignore-nix": "gitignore-nix_9",
         "hackage-nix": "hackage-nix_9",
-        "haskell-language-server": "haskell-language-server_27",
+        "haskell-language-server": "haskell-language-server_18",
         "haskell-nix": "haskell-nix_18",
         "iohk-nix": "iohk-nix_18",
-        "nixpkgs": "nixpkgs_43",
+        "nixpkgs": "nixpkgs_37",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_9",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_9"
       },
       "locked": {
-        "lastModified": 1653669501,
-        "narHash": "sha256-qJrjEeo9Jmar1TwihDFzKQNC1ui4M03iClJM1zMd5Uk=",
+        "lastModified": 1656595231,
+        "narHash": "sha256-3EBhSroECMOSP02qZGT0Zb3QHWibI/tYjdcaT5/YotY=",
         "owner": "input-output-hk",
         "repo": "plutus",
-        "rev": "fed48a71550a12290efc84eefb74305d93cde69d",
+        "rev": "b39a526e983cb931d0cc49b7d073d6d43abd22b5",
         "type": "github"
       },
       "original": {
@@ -13039,6 +12866,38 @@
       }
     },
     "pre-commit-hooks-nix_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix_15": {
       "flake": false,
       "locked": {
         "lastModified": 1624971177,
@@ -13233,21 +13092,52 @@
     "protolude_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1637276813,
-        "narHash": "sha256-/mgR1Vyp1WYBjdkbwQycrf6lcmOgUFcYUZIMhVgYhdo=",
+        "lastModified": 1647139352,
+        "narHash": "sha256-JyHAQfTTUswP8MeGEZibx/2/v01Q7cU5mNpnmDazh24=",
         "owner": "protolude",
         "repo": "protolude",
-        "rev": "d821ef0ac7552cfa2c3e7a7bdf29539f57e3fae6",
+        "rev": "3e249724fd0ead27370c8c297b1ecd38f92cbd5b",
         "type": "github"
       },
       "original": {
         "owner": "protolude",
         "repo": "protolude",
-        "rev": "d821ef0ac7552cfa2c3e7a7bdf29539f57e3fae6",
         "type": "github"
       }
     },
     "protolude_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647139352,
+        "narHash": "sha256-JyHAQfTTUswP8MeGEZibx/2/v01Q7cU5mNpnmDazh24=",
+        "owner": "protolude",
+        "repo": "protolude",
+        "rev": "3e249724fd0ead27370c8c297b1ecd38f92cbd5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "protolude",
+        "repo": "protolude",
+        "type": "github"
+      }
+    },
+    "protolude_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647139352,
+        "narHash": "sha256-JyHAQfTTUswP8MeGEZibx/2/v01Q7cU5mNpnmDazh24=",
+        "owner": "protolude",
+        "repo": "protolude",
+        "rev": "3e249724fd0ead27370c8c297b1ecd38f92cbd5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "protolude",
+        "repo": "protolude",
+        "type": "github"
+      }
+    },
+    "protolude_15": {
       "flake": false,
       "locked": {
         "lastModified": 1647139352,
@@ -13393,10 +13283,23 @@
     },
     "root": {
       "inputs": {
+        "haskell-language-server": [
+          "plutarch",
+          "haskell-language-server"
+        ],
         "haskell-nix": [
           "plutarch",
           "haskell-nix"
         ],
+        "haskell-nix-extra-hackage": [
+          "plutarch",
+          "haskell-nix-extra-hackage"
+        ],
+        "iohk-nix": [
+          "plutarch",
+          "iohk-nix"
+        ],
+        "liqwid-nix": "liqwid-nix",
         "liqwid-plutarch-extra": "liqwid-plutarch-extra",
         "nixpkgs": [
           "plutarch",
@@ -13461,6 +13364,54 @@
       }
     },
     "secp256k1-haskell_12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650290419,
+        "narHash": "sha256-XrjiqCC7cNTFib78gdMPGNettAkwAxQlbC/n+/mRFt4=",
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "rev": "3df963ab6ae14ec122691a97af09a7331511a387",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "type": "github"
+      }
+    },
+    "secp256k1-haskell_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650290419,
+        "narHash": "sha256-XrjiqCC7cNTFib78gdMPGNettAkwAxQlbC/n+/mRFt4=",
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "rev": "3df963ab6ae14ec122691a97af09a7331511a387",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "type": "github"
+      }
+    },
+    "secp256k1-haskell_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650290419,
+        "narHash": "sha256-XrjiqCC7cNTFib78gdMPGNettAkwAxQlbC/n+/mRFt4=",
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "rev": "3df963ab6ae14ec122691a97af09a7331511a387",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskoin",
+        "repo": "secp256k1-haskell",
+        "type": "github"
+      }
+    },
+    "secp256k1-haskell_15": {
       "flake": false,
       "locked": {
         "lastModified": 1650290419,
@@ -13604,23 +13555,6 @@
         "type": "github"
       }
     },
-    "sized-functors": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1620614934,
-        "narHash": "sha256-pVJbEGF4/lvXmWIypwkMQBYygOx3TQwLJbMpfdYovdY=",
-        "owner": "JonasDuregard",
-        "repo": "sized-functors",
-        "rev": "fe6bf78a1b97ff7429630d0e8974c9bc40945dcf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "JonasDuregard",
-        "repo": "sized-functors",
-        "rev": "fe6bf78a1b97ff7429630d0e8974c9bc40945dcf",
-        "type": "github"
-      }
-    },
     "sphinxcontrib-haddock": {
       "flake": false,
       "locked": {
@@ -13686,6 +13620,38 @@
       }
     },
     "sphinxcontrib-haddock_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1594136664,
+        "narHash": "sha256-O9YT3iCUBHP3CEF88VDLLCO2HSP3HqkNA2q2939RnVY=",
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "rev": "f3956b3256962b2d27d5a4e96edb7951acf5de34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "type": "github"
+      }
+    },
+    "sphinxcontrib-haddock_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1594136664,
+        "narHash": "sha256-O9YT3iCUBHP3CEF88VDLLCO2HSP3HqkNA2q2939RnVY=",
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "rev": "f3956b3256962b2d27d5a4e96edb7951acf5de34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "type": "github"
+      }
+    },
+    "sphinxcontrib-haddock_15": {
       "flake": false,
       "locked": {
         "lastModified": 1594136664,
@@ -13845,22 +13811,6 @@
         "type": "github"
       }
     },
-    "stackage-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1597712578,
-        "narHash": "sha256-c/pcfZ6w5Yp//7oC0hErOGVVphBLc5vc4IZlWKZ/t6E=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "e32c8b06d56954865725514ce0d98d5d1867e43a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
     "stackage_10": {
       "flake": false,
       "locked": {
@@ -13896,11 +13846,11 @@
     "stackage_12": {
       "flake": false,
       "locked": {
-        "lastModified": 1644887829,
-        "narHash": "sha256-tjUXJpqB7MMnqM4FF5cdtZipfratUcTKRQVA6F77sEQ=",
+        "lastModified": 1654046327,
+        "narHash": "sha256-IxX46Dh4OZpF3k7KPMa3tZSScYYGqFxXpCnMc0QRkuQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "db8bdef6588cf4f38e6069075ba76f0024381f68",
+        "rev": "cc1d778723fcd431f9b2ed632a50c610c3e38b54",
         "type": "github"
       },
       "original": {
@@ -13910,6 +13860,38 @@
       }
     },
     "stackage_13": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654046327,
+        "narHash": "sha256-IxX46Dh4OZpF3k7KPMa3tZSScYYGqFxXpCnMc0QRkuQ=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "cc1d778723fcd431f9b2ed632a50c610c3e38b54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_14": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654046327,
+        "narHash": "sha256-IxX46Dh4OZpF3k7KPMa3tZSScYYGqFxXpCnMc0QRkuQ=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "cc1d778723fcd431f9b2ed632a50c610c3e38b54",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_15": {
       "flake": false,
       "locked": {
         "lastModified": 1654046327,
@@ -14050,341 +14032,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell": {
-      "inputs": {
-        "ema": [
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_10": {
-      "inputs": {
-        "ema": [
-          "plutarch-safe-money",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_20",
-        "flake-utils": "flake-utils_30",
-        "nixpkgs": "nixpkgs_50"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_11": {
-      "inputs": {
-        "flake-compat": "flake-compat_23",
-        "flake-utils": "flake-utils_35",
-        "nixpkgs": "nixpkgs_56"
-      },
-      "locked": {
-        "lastModified": 1649519562,
-        "narHash": "sha256-IVZ4D7JkSCn0sjeTw5b0s2TTIU+g4hk78u1znXY4JjQ=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "f5bfc15da3ee6e74a077579fb10269bb450fa5cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_2": {
-      "inputs": {
-        "ema": [
-          "liqwid-plutarch-extra",
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_7"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_3": {
-      "inputs": {
-        "ema": [
-          "liqwid-plutarch-extra",
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_12"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_4": {
-      "inputs": {
-        "ema": [
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_8",
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_17"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_5": {
-      "inputs": {
-        "ema": [
-          "plutarch-context-builder",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_10",
-        "flake-utils": "flake-utils_15",
-        "nixpkgs": "nixpkgs_25"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_6": {
-      "inputs": {
-        "ema": [
-          "plutarch-numeric",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_12",
-        "flake-utils": "flake-utils_18",
-        "nixpkgs": "nixpkgs_30"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_7": {
-      "inputs": {
-        "ema": [
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_14",
-        "flake-utils": "flake-utils_21",
-        "nixpkgs": "nixpkgs_35"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_8": {
-      "inputs": {
-        "ema": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_16",
-        "flake-utils": "flake-utils_24",
-        "nixpkgs": "nixpkgs_40"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "tailwind-haskell_9": {
-      "inputs": {
-        "ema": [
-          "plutarch-safe-money",
-          "liqwid-plutarch-extra",
-          "plutarch-quickcheck",
-          "plutarch",
-          "emanote",
-          "ema"
-        ],
-        "flake-compat": "flake-compat_18",
-        "flake-utils": "flake-utils_27",
-        "nixpkgs": "nixpkgs_45"
-      },
-      "locked": {
-        "lastModified": 1653230344,
-        "narHash": "sha256-MNwayqvZHsIsP1uyqwQFvzcfFGBMejzZOqAapDjrV5I=",
-        "owner": "srid",
-        "repo": "tailwind-haskell",
-        "rev": "0fb8a18b0e770bafc17521836658f31c56e6dfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "tailwind-haskell",
-        "type": "github"
-      }
-    },
-    "th-extras": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641329261,
-        "narHash": "sha256-+K91xH/zew66ry0EAV5FaEIAHUZdJ3ngD9GzCJiUq7k=",
-        "owner": "mokus0",
-        "repo": "th-extras",
-        "rev": "787ed752c1e5d41b5903b74e171ed087de38bffa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mokus0",
-        "repo": "th-extras",
-        "rev": "787ed752c1e5d41b5903b74e171ed087de38bffa",
-        "type": "github"
-      }
-    },
-    "unionmount": {
-      "inputs": {
-        "flake-compat": "flake-compat_24",
-        "flake-utils": "flake-utils_36",
-        "nixpkgs": "nixpkgs_57"
-      },
-      "locked": {
-        "lastModified": 1649012450,
-        "narHash": "sha256-m0qlPd3jxjyDEkd7cQKLX0GT9a00qnvygec9GCBZ1hc=",
-        "owner": "srid",
-        "repo": "unionmount",
-        "rev": "27584567d9182c12018f988db899593a896f86ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "ref": "master",
-        "repo": "unionmount",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,263 +1,109 @@
 {
   description = "agora";
 
-  inputs.nixpkgs.follows = "plutarch/nixpkgs";
-  inputs.haskell-nix.follows = "plutarch/haskell-nix";
-  inputs.nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=a0a69be4b5ee63f1b5e75887a406e9194012b492";
-  # temporary fix for nix versions that have the transitive follows bug
-  # see https://github.com/NixOS/nix/issues/6013
-  inputs.nixpkgs-2111 = { url = "github:NixOS/nixpkgs/nixpkgs-21.11-darwin"; };
+  inputs = {
+    nixpkgs.follows = "plutarch/nixpkgs";
+    nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=cf63df0364f67848083ff75bc8ac9b7ca7aa5a01";
+    # temporary fix for nix versions that have the transitive follows bug
+    # see https://github.com/NixOS/nix/issues/6013
+    nixpkgs-2111 = { url = "github:NixOS/nixpkgs/nixpkgs-21.11-darwin"; };
 
-  # Plutarch and its friends
-  inputs.plutarch.url =
-    "github:liqwid-labs/plutarch?rev=e7ef565645146e26e75ec29fe97122a74e52c6b7";
-  inputs.plutarch.inputs.emanote.follows =
-    "plutarch/haskell-nix/nixpkgs-unstable";
-  inputs.plutarch.inputs.nixpkgs.follows =
-    "plutarch/haskell-nix/nixpkgs-unstable";
+    haskell-nix-extra-hackage.follows = "plutarch/haskell-nix-extra-hackage";
+    haskell-nix.follows = "plutarch/haskell-nix";
+    iohk-nix.follows = "plutarch/iohk-nix";
+    haskell-language-server.follows = "plutarch/haskell-language-server";
 
-  inputs.liqwid-plutarch-extra.url =
-    "github:Liqwid-Labs/liqwid-plutarch-extra?ref=seungheonoh/agoraUtils";
-  inputs.plutarch-numeric.url =
-    "github:Liqwid-Labs/plutarch-numeric?ref=main";
-  inputs.plutarch-safe-money.url =
-    "github:Liqwid-Labs/plutarch-safe-money?rev=9f968b80189c7e4b335527cd5b103dc26952f667";
+    # Plutarch and its friends
+    plutarch = {
+      url = "github:Plutonomicon/plutarch-plutus?ref=staging";
 
-  inputs.plutarch-script-export.url =
-    "github:Liqwid-Labs/plutarch-script-export?ref=main";
+      inputs.emanote.follows =
+        "plutarch/haskell-nix/nixpkgs-unstable";
+      inputs.nixpkgs.follows =
+        "plutarch/haskell-nix/nixpkgs-unstable";
+    };
 
-  # Testing
-  inputs.plutarch-quickcheck.url =
-    "github:liqwid-labs/plutarch-quickcheck?ref=staging";
+    plutarch-numeric.url =
+      "github:Liqwid-Labs/plutarch-numeric?ref=main";
+    plutarch-safe-money.url =
+      "github:Liqwid-Labs/plutarch-safe-money?ref=main";
+    liqwid-plutarch-extra.url =
+      "github:Liqwid-Labs/liqwid-plutarch-extra?ref=plutus-v1";
+    plutarch-quickcheck.url =
+      "github:liqwid-labs/plutarch-quickcheck?ref=staging";
+    plutarch-context-builder.url =
+      "github:Liqwid-Labs/plutarch-context-builder?ref=plutus-v1";
+    plutarch-script-export.url =
+      "github:Liqwid-Labs/plutarch-script-export?ref=main";
 
-  # PCB Rev is locked until Agora test have explicit Minting CS. Check PCB PR #12
-  inputs.plutarch-context-builder.url =
-    "github:Liqwid-Labs/plutarch-context-builder?ref=2a2ca72ff310788e531cbbe379ef7b0c4cb42dc9";
+    liqwid-nix.url = "github:Liqwid-Labs/liqwid-nix?ref=main";
+  };
 
-  outputs = inputs@{ self, nixpkgs, nixpkgs-latest, haskell-nix, plutarch, ... }:
+  outputs = inputs@{ liqwid-nix, ... }:
     let
-      supportedSystems = nixpkgs-latest.lib.systems.flakeExposed;
-
-      perSystem = nixpkgs.lib.genAttrs supportedSystems;
-
-      pkgsFor = system: import nixpkgs {
-        inherit system;
-        overlays = [ haskell-nix.overlay (import "${plutarch.inputs.iohk-nix}/overlays/crypto") ];
-        # This only does bad things for us...
-        # inherit (haskell-nix) config;
-      };
-      pkgsFor' = system: import nixpkgs-latest { inherit system; };
-
-      fourmoluFor = system: (pkgsFor' system).haskell.packages.ghc922.fourmolu_0_6_0_0;
-
-      defaultGhcVersion = "ghc923";
-
-      nonReinstallablePkgs = [
-        "array"
-        "array"
-        "base"
-        "binary"
-        "bytestring"
-        "Cabal"
-        "containers"
-        "deepseq"
-        "directory"
-        "exceptions"
-        "filepath"
-        "ghc"
-        "ghc-bignum"
-        "ghc-boot"
-        "ghc-boot"
-        "ghc-boot-th"
-        "ghc-compact"
-        "ghc-heap"
-        # "ghci"
-        # "haskeline"
-        "ghcjs-prim"
-        "ghcjs-th"
-        "ghc-prim"
-        "ghc-prim"
-        "hpc"
-        "integer-gmp"
-        "integer-simple"
-        "mtl"
-        "parsec"
-        "pretty"
-        "process"
-        "rts"
-        "stm"
-        "template-haskell"
-        "terminfo"
-        "text"
-        "time"
-        "transformers"
-        "unix"
-        "Win32"
-        "xhtml"
-      ];
-
-      haskellModules = [
-        ({ config, pkgs, hsPkgs, ... }: {
-          inherit nonReinstallablePkgs; # Needed for a lot of different things
-          packages = {
-            cardano-binary.doHaddock = false;
-            cardano-binary.ghcOptions = [ "-Wwarn" ];
-            cardano-crypto-class.components.library.pkgconfig = pkgs.lib.mkForce [ [ pkgs.libsodium-vrf ] ];
-            cardano-crypto-class.doHaddock = false;
-            cardano-crypto-class.ghcOptions = [ "-Wwarn" ];
-            cardano-crypto-praos.components.library.pkgconfig = pkgs.lib.mkForce [ [ pkgs.libsodium-vrf ] ];
-            cardano-prelude.doHaddock = false; # somehow above options are not applied?
-            cardano-prelude.ghcOptions = [ "-Wwarn" ];
-            # Workaround missing support for build-tools:
-            # https://github.com/input-output-hk/haskell.nix/issues/231
-            plutarch-test.components.exes.plutarch-test.build-tools = [
-              config.hsPkgs.hspec-discover
-            ];
+      benchCheckOverlay = self: super: {
+        toFlake =
+          let
+            inherit (self) inputs perSystem pkgsFor';
+            flake = super.toFlake or { };
+            name = "benchCheck";
+          in
+          flake // {
+            checks = perSystem (system:
+              flake.checks.${system} // {
+                ${name} =
+                  let
+                    pkgs' = pkgsFor' system;
+                    bench = flake.packages.${system}."agora:bench:agora-bench";
+                  in
+                  pkgs'.runCommand name
+                    {
+                      nativeBuildInputs = [ pkgs'.diffutils ];
+                    } ''
+                    export LC_CTYPE=C.UTF-8
+                    export LC_ALL=C.UTF-8
+                    export LANG=C.UTF-8
+                    cd ${inputs.self}
+                    ${bench}/bin/agora-bench | diff bench.csv - \
+                      || (echo "bench.csv is outdated"; exit 1)
+                    mkdir "$out"
+                  '';
+              });
           };
-        })
-      ];
-
-      myhackage = system: compiler-nix-name: plutarch.inputs.haskell-nix-extra-hackage.mkHackageFor system compiler-nix-name (
-        [
-          "${inputs.plutarch.inputs.flat}"
-          "${inputs.plutarch.inputs.protolude}"
-          "${inputs.plutarch.inputs.cardano-prelude}/cardano-prelude"
-          "${inputs.plutarch.inputs.cardano-crypto}"
-          "${inputs.plutarch.inputs.cardano-base}/binary"
-          "${inputs.plutarch.inputs.cardano-base}/cardano-crypto-class"
-          "${inputs.plutarch.inputs.plutus}/plutus-core"
-          "${inputs.plutarch.inputs.plutus}/plutus-ledger-api"
-          "${inputs.plutarch.inputs.plutus}/plutus-tx"
-          "${inputs.plutarch.inputs.plutus}/prettyprinter-configurable"
-          "${inputs.plutarch.inputs.plutus}/word-array"
-          "${inputs.plutarch.inputs.secp256k1-haskell}"
-          "${inputs.plutarch.inputs.plutus}/plutus-tx-plugin" # necessary for FFI tests
-
-          # Custom deps as a consumer
-          "${inputs.plutarch}"
-          "${inputs.plutarch}/plutarch-extra"
-          "${inputs.liqwid-plutarch-extra}"
+      };
+    in
+    (liqwid-nix.buildProject
+      {
+        inherit inputs;
+        src = ./.;
+      }
+      [
+        liqwid-nix.haskellProject
+        liqwid-nix.plutarchProject
+        (liqwid-nix.addDependencies [
           "${inputs.plutarch-numeric}"
           "${inputs.plutarch-safe-money}"
           "${inputs.plutarch-quickcheck}"
           "${inputs.plutarch-context-builder}"
+          "${inputs.liqwid-plutarch-extra}"
           "${inputs.plutarch-script-export}"
-        ]
-      );
-
-      applyDep = pkgs: o:
-        let
-          h = myhackage pkgs.system o.compiler-nix-name;
-          o' = (plutarch.applyPlutarchDep pkgs o);
-        in
-        o' // rec {
-          modules = haskellModules ++ [ h.module ] ++ (o'.modules or [ ]);
-          extra-hackages = [ (import h.hackageNix) ] ++ (o'.extra-hackages or [ ]);
-          extra-hackage-tarballs = { _xNJUd_plutarch-hackage = h.hackageTarball; };
-          cabalProjectLocal = (o'.cabalProjectLocal or "") + "  , cache >= 0.1.3.0 ";
-        };
-
-      projectForGhc = compiler-nix-name: system:
-        let pkgs = pkgsFor system; in
-        let pkgs' = pkgsFor' system; in
-        let pkgSet = pkgs.haskell-nix.cabalProject' (applyDep pkgs {
-          src = ./.;
-          inherit compiler-nix-name;
-          modules = [ ];
-          shell = {
-            withHoogle = true;
-
-            exactDeps = true;
-
-            # We use the ones from Nixpkgs, since they are cached reliably.
-            # Eventually we will probably want to build these with haskell.nix.
-            nativeBuildInputs = [
-              pkgs'.cabal-install
-              pkgs'.hlint
-              pkgs'.haskellPackages.cabal-fmt
-              (fourmoluFor system)
-              pkgs'.nixpkgs-fmt
-              (plutarch.hlsFor compiler-nix-name system)
-            ];
-          };
-        }); in
-        pkgSet;
-
-      projectFor = projectForGhc defaultGhcVersion;
-
-      formatCheckFor = system:
-        let
-          pkgs' = pkgsFor' system;
-        in
-        pkgs'.runCommand "format-check"
-          {
-            nativeBuildInputs = [ pkgs'.haskellPackages.cabal-fmt pkgs'.nixpkgs-fmt (fourmoluFor system) pkgs'.hlint ];
-          } ''
-          export LC_CTYPE=C.UTF-8
-          export LC_ALL=C.UTF-8
-          export LANG=C.UTF-8
-          cd ${self}
-          make format_check || (echo "    Please run 'make format'" ; exit 1)
-          find -name '*.hs' -not -path './dist*/*' -not -path './haddock/*' | xargs hlint
-          mkdir $out
-        ''
-      ;
-
-      benchCheckFor = system: agora-bench:
-        let
-          pkgs = pkgsFor system;
-          pkgs' = pkgsFor' system;
-        in
-        pkgs.runCommand "bench-check"
-          {
-            bench = "${agora-bench}/bin/agora-bench";
-            nativeBuildInputs = [
-              pkgs'.diffutils
-            ];
-          } ''
-          export LC_CTYPE=C.UTF-8
-          export LC_ALL=C.UTF-8
-          export LANG=C.UTF-8
-          cd ${self}
-          make bench_check || (echo "    Please run 'make bench'" ; exit 1)
-          mkdir $out 
-        '';
-    in
-    {
-      project = perSystem projectFor;
-      flake = perSystem (system: (projectFor system).flake { });
-
-      packages = perSystem (system:
-        self.flake.${system}.packages // {
-          haddock =
-            let
-              agora-doc = self.flake.${system}.packages."agora:lib:agora".doc;
-              pkgs = pkgsFor system;
-            in
-            pkgs.runCommand "haddock-merge" { } ''
-              cd ${self}
-              mkdir $out
-              cp -r ${agora-doc}/share/doc/* $out
-            '';
-        });
-
-      # Define what we want to test
-      checks = perSystem (system:
-        self.flake.${system}.checks // {
-          formatCheck = formatCheckFor system;
-          # benchCheck = benchCheckFor system self.flake.${system}.packages."agora:bench:agora-bench";
-          agora = self.flake.${system}.packages."agora:lib:agora";
-          agora-test = self.flake.${system}.packages."agora:test:agora-test";
-          benchCheck = benchCheckFor system self.flake.${system}.packages."agora:bench:agora-bench";
-        });
-      check = perSystem (system:
-        (pkgsFor system).runCommand "combined-test"
-          {
-            checksss = builtins.attrValues self.checks.${system};
-          } ''
-          echo $checksss
-          touch $out
-        '');
-      devShell = perSystem (system: self.flake.${system}.devShell);
-    };
+        ])
+        (liqwid-nix.enableFormatCheck [
+          "-XQuasiQuotes"
+          "-XTemplateHaskell"
+          "-XTypeApplications"
+          "-XImportQualifiedPost"
+          "-XPatternSynonyms"
+          "-XOverloadedRecordDot"
+        ])
+        liqwid-nix.enableLintCheck
+        liqwid-nix.enableCabalFormatCheck
+        liqwid-nix.enableNixFormatCheck
+        liqwid-nix.addBuildChecks
+        (liqwid-nix.addCommandLineTools (pkgs: _: [
+          pkgs.haskellPackages.hasktags
+        ]))
+        benchCheckOverlay
+      ]
+    ).toFlake;
 }


### PR DESCRIPTION
This pr bumps plutarch to version 1.2 and refactors the nix setup with `liqwid-nix`. 

Some caveats regrading the new version of plutarch:

- Unable to derive`PDataFields`for a newtype of `PDataRecord`, which derives its `PlutusType` instance using `PlutusTypeNewtype` strategy. Workaround: `pto` before `pletField`.
- Missing `PTryfrom PData` instances for `PAsData _`/`PUnit`/`PDatumHash`. Workaround: implemented orphan instances in `Agora.Plutarch.Orphans`. Great thanks to @emiflake for debugging a plutarch compile time infinite recursion bug related to this!
- `development` flag which controled whether to include tracing message in the compiled scripts or not has been replaced by `Config`. This dramatically changes the way we parameterize the scripts, especially when they have dependent relationship.
- Addition logic of plutarch's compilation pipeline has slowdowned the compilation speed quite a bit, meaning that we have to compile scripts ahead of time for benchmarking and testing purposes. With this strategy, our sample test suite (which contains 1053 test cases) can now finish in 2.17~s (Apple M1, 8 threads), which is 250 times faster. 