### PR TITLE
Add kind signatures where missing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This really ought to be `/usr/bin/env bash`, but nix flakes don't like that.
 SHELL := /bin/sh
 
-.PHONY: hoogle format haddock usage tag format_nix format_haskell format_check	\ 
+.PHONY: hoogle format haddock usage tag format_nix format_haskell format_check	\
 				lint refactor ps_bridge bench bench_check scripts test build ci
 
 SOURCE_FILES := $(shell git ls-tree -r HEAD --full-tree --name-only)
@@ -98,4 +98,7 @@ test: requires_nix_shell
 build: requires_nix_shell
 	cabal build -j$(THREADS)
 
-ci: format_check lint build bench_check test haddock
+ci:
+	@ [[ "$$(uname -sm)" == "Linux x86_64" ]] \
+	  && (nix build .#check.x86_64-linux) \
+	  || (echo "CI only builds on Linux x86_64. Your system is $$(uname -sm). If you want to build it for your system, use 'nix build .#check.<your system>' instead." && false)

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,5 @@ build: requires_nix_shell
 	cabal build -j$(THREADS)
 
 ci:
-	@ [[ "$$(uname -sm)" == "Linux x86_64" ]] \
-	  && (nix build .#check.x86_64-linux) \
-	  || (echo "CI only builds on Linux x86_64. Your system is $$(uname -sm). If you want to build it for your system, use 'nix build .#check.<your system>' instead." && false)
+	@ [[ "$$(uname -sm)" == "Linux x86_64" ]] || (echo "NOTE: CI only builds on Linux x86_64. Your system is $$(uname -sm), continuing...")
+	nix build .#check.$(shell nix eval -f '<nixpkgs>' system)

--- a/agora/Agora/AuthorityToken.hs
+++ b/agora/Agora/AuthorityToken.hs
@@ -21,13 +21,13 @@ import Plutarch.Api.V1.Value (PValue (PValue))
 import Plutarch.Api.V2 (
   AmountGuarantees,
   KeyGuarantees,
-  PAddress (..),
+  PAddress (PAddress),
   PMintingPolicy,
-  PScriptContext (..),
-  PScriptPurpose (..),
+  PScriptContext (PScriptContext),
+  PScriptPurpose (PMinting),
   PTxInInfo (PTxInInfo),
-  PTxInfo (..),
-  PTxOut (..),
+  PTxInfo (PTxInfo),
+  PTxOut (PTxOut),
  )
 import Plutarch.Extra.AssetClass (passetClass, passetClassValueOf)
 import Plutarch.Extra.List (plookup)
@@ -74,7 +74,7 @@ newtype AuthorityToken = AuthorityToken
 
      @since 0.1.0
 -}
-authorityTokensValidIn :: Term s (PCurrencySymbol :--> PTxOut :--> PBool)
+authorityTokensValidIn :: forall (s :: S). Term s (PCurrencySymbol :--> PTxOut :--> PBool)
 authorityTokensValidIn = phoistAcyclic $
   plam $ \authorityTokenSym txOut'' -> unTermCont $ do
     PTxOut txOut' <- pmatchC txOut''

--- a/agora/Agora/Credential.hs
+++ b/agora/Agora/Credential.hs
@@ -46,7 +46,7 @@ instance DerivePlutusType PAuthorizationContext where
      @since 1.0.0
 -}
 authorizationContext ::
-  forall (s :: S) r.
+  forall (s :: S) (r :: Type).
   ( HasField "inputs" r (Term s (PBuiltinList PTxInInfo))
   , HasField "signatories" r (Term s (PBuiltinList (PAsData PPubKeyHash)))
   ) =>

--- a/agora/Agora/Governor.hs
+++ b/agora/Agora/Governor.hs
@@ -232,7 +232,7 @@ deriving via (DerivePConstantViaEnum GovernorRedeemer PGovernorRedeemer) instanc
 
      @since 0.1.0
 -}
-pgetNextProposalId :: Term s (PProposalId :--> PProposalId)
+pgetNextProposalId :: forall (s :: S). Term s (PProposalId :--> PProposalId)
 pgetNextProposalId = phoistAcyclic $ plam $ \(pto -> pid) -> pcon $ PProposalId $ pid + 1
 
 {- | Get next proposal id.
@@ -248,7 +248,7 @@ getNextProposalId (ProposalId pid) = ProposalId $ pid + 1
 
      @since 0.1.0
 -}
-pisGovernorDatumValid :: Term s (PGovernorDatum :--> PBool)
+pisGovernorDatumValid :: forall (s :: S). Term s (PGovernorDatum :--> PBool)
 pisGovernorDatumValid = phoistAcyclic $
   plam $ \datum -> unTermCont $ do
     datumF <-

--- a/agora/Agora/Governor/Scripts.hs
+++ b/agora/Agora/Governor/Scripts.hs
@@ -503,7 +503,9 @@ governorValidator as =
 
           -- For a given output, check if it contains a single valid GAT
           -- and whether it correctly belongs to the group.
-          let validateGATOutput' :: Term s (PProposalEffectGroup :--> PTxOut :--> PBool)
+          let validateGATOutput' ::
+                forall (s :: S).
+                Term s (PProposalEffectGroup :--> PTxOut :--> PBool)
               validateGATOutput' =
                 phoistAcyclic $
                   plam
@@ -569,7 +571,7 @@ governorValidator as =
         Nothing -> ptraceError "Unknown redeemer"
   where
     -- The currency symbol of authority token.
-    atSymbol :: Term s PCurrencySymbol
+    atSymbol :: forall (s :: S). Term s PCurrencySymbol
     atSymbol = pconstant $ authorityTokenSymbol as
 
     -- The currency symbol of the proposal state token.

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -746,6 +746,7 @@ pisVotesEmpty = phoistAcyclic $
      @since 0.1.0
 -}
 pwinner ::
+  forall (s :: S).
   Term
     s
     ( PProposalVotes
@@ -766,6 +767,7 @@ pwinner = phoistAcyclic $
      @since 0.1.0
 -}
 pwinner' ::
+  forall (s :: S).
   Term
     s
     ( PProposalVotes
@@ -813,6 +815,7 @@ pwinner' = phoistAcyclic $
      @since 0.1.0
 -}
 phighestVotes ::
+  forall (s :: S).
   Term
     s
     ( PProposalVotes
@@ -835,6 +838,7 @@ phighestVotes = phoistAcyclic $
      @since 0.1.0
 -}
 pneutralOption ::
+  forall (s :: S).
   Term
     s
     ( PMap 'Unsorted PResultTag PProposalEffectGroup
@@ -883,7 +887,7 @@ pisProposalThresholdsValid = phoistAcyclic $
 
      @since 0.1.0
 -}
-pretractVotes :: Term s (PResultTag :--> PInteger :--> PProposalVotes :--> PProposalVotes)
+pretractVotes :: forall (s :: S). Term s (PResultTag :--> PInteger :--> PProposalVotes :--> PProposalVotes)
 pretractVotes = phoistAcyclic $
   plam $ \rt count votes ->
     let voteMap :: Term _ (PMap 'Unsorted PResultTag PInteger)

--- a/agora/Agora/Proposal/Time.hs
+++ b/agora/Agora/Proposal/Time.hs
@@ -294,7 +294,7 @@ deriving via
 
      @since 0.2.0
 -}
-pisProposalTimingConfigValid :: Term s (PProposalTimingConfig :--> PBool)
+pisProposalTimingConfigValid :: forall (s :: S). Term s (PProposalTimingConfig :--> PBool)
 pisProposalTimingConfigValid = phoistAcyclic $
   plam $ \conf -> unTermCont $ do
     confF <- pletAllC conf
@@ -397,6 +397,7 @@ currentProposalTime = phoistAcyclic $
      @since 0.1.0
 -}
 proposalTimeWithin ::
+  forall (s :: S).
   Term
     s
     ( PPOSIXTime

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -366,7 +366,9 @@ pstakeLocked = phoistAcyclic $
 
      @since 0.2.0
 -}
-pnumCreatedProposals :: Term s (PBuiltinList (PAsData PProposalLock) :--> PInteger)
+pnumCreatedProposals ::
+  forall (s :: S).
+  Term s (PBuiltinList (PAsData PProposalLock) :--> PInteger)
 pnumCreatedProposals =
   phoistAcyclic $
     plam $ \l ->
@@ -414,7 +416,7 @@ instance DerivePlutusType PStakeRole where
 
      @since 0.2.0
 -}
-pisVoter :: Term s (PStakeRole :--> PBool)
+pisVoter :: forall (s :: S). Term s (PStakeRole :--> PBool)
 pisVoter = phoistAcyclic $
   plam $ \sr -> pmatch sr $ \case
     PVoter _ -> pconstant True
@@ -425,7 +427,7 @@ pisVoter = phoistAcyclic $
 
      @since 0.2.0
 -}
-pisCreator :: Term s (PStakeRole :--> PBool)
+pisCreator :: forall (s :: S). Term s (PStakeRole :--> PBool)
 pisCreator = phoistAcyclic $
   plam $ \sr -> pmatch sr $ \case
     PCreator -> pconstant True
@@ -437,7 +439,7 @@ pisCreator = phoistAcyclic $
 
      @since 0.2.0
 -}
-pisPureCreator :: Term s (PStakeRole :--> PBool)
+pisPureCreator :: forall (s :: S). Term s (PStakeRole :--> PBool)
 pisPureCreator = phoistAcyclic $
   plam $ \sr -> pmatch sr $ \case
     PCreator -> pconstant True
@@ -447,7 +449,7 @@ pisPureCreator = phoistAcyclic $
 
      @since 0.2.0
 -}
-pisIrrelevant :: Term s (PStakeRole :--> PBool)
+pisIrrelevant :: forall (s :: S). Term s (PStakeRole :--> PBool)
 pisIrrelevant = phoistAcyclic $
   plam $ \sr -> pmatch sr $ \case
     PIrrelevant -> pconstant True
@@ -461,7 +463,7 @@ pisIrrelevant = phoistAcyclic $
 
      @since 0.2.0
 -}
-pgetStakeRole :: Term s (PProposalId :--> PBuiltinList (PAsData PProposalLock) :--> PStakeRole)
+pgetStakeRole :: forall (s :: S). Term s (PProposalId :--> PBuiltinList (PAsData PProposalLock) :--> PStakeRole)
 pgetStakeRole = phoistAcyclic $
   plam $ \pid locks ->
     pfoldl
@@ -483,7 +485,7 @@ pgetStakeRole = phoistAcyclic $
       # pcon PIrrelevant
       # locks
   where
-    pcombineStakeRole :: Term s (PStakeRole :--> PStakeRole :--> PStakeRole)
+    pcombineStakeRole :: forall (s :: S). Term s (PStakeRole :--> PStakeRole :--> PStakeRole)
     pcombineStakeRole = phoistAcyclic $
       plam $ \x y ->
         let cannotCombine = ptraceError "duplicate roles"
@@ -503,7 +505,7 @@ pgetStakeRole = phoistAcyclic $
 
      @since 0.2.0
 -}
-pextractVoteOption :: Term s (PStakeRole :--> PResultTag)
+pextractVoteOption :: forall (s :: S). Term s (PStakeRole :--> PResultTag)
 pextractVoteOption = phoistAcyclic $
   plam $ \sr -> pmatch sr $ \case
     PVoter r -> r


### PR DESCRIPTION
Summary:
- Adds kind signatures where they are missing. As well as missing foralls.
- Make `make ci` _actually_ 1:1 consistent with CI. 