### PR TITLE
Update the codebase to the new coding standards - labeled optics migration 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ HASKELL_SOURCES := $(filter %.hs,$(SOURCE_FILES))
 CABAL_SOURCES := $(filter %.cabal,$(SOURCE_FILES))
 NIX_SOURCES := $(filter %.nix,$(SOURCE_FILES))
 FORMAT_EXTENSIONS := -o -XQuasiQuotes -o -XTemplateHaskell -o -XTypeApplications	\
-										-o -XImportQualifiedPost -o -XPatternSynonyms -o -XOverloadedRecordDot
+										-o -XImportQualifiedPost -o -XPatternSynonyms
 HLINT_EXTS := -XQuasiQuotes
 
 THREADS ?= 8

--- a/agora-bench/Main.hs
+++ b/agora-bench/Main.hs
@@ -25,7 +25,7 @@ main = do
   options <- parseOptions
   isTTY <- hIsTerminalDevice stdout
 
-  mapM_ (`I.writeFile` csv) options.output
+  mapM_ (`I.writeFile` csv) $ getField @"output" options
 
   I.putStr $
     if isTTY

--- a/agora-purescript-bridge/Bridge.hs
+++ b/agora-purescript-bridge/Bridge.hs
@@ -21,8 +21,8 @@ main :: IO ()
 main = do
   options <- parseOptions
 
-  unless options.quiet $ do
-    putStrLn $ "Writing purescript stuff to " <> options.output
+  unless (getField @"quiet" options) $ do
+    putStrLn $ "Writing purescript stuff to " <> getField @"output" options
     putStrLn ""
 
-  writePSTypes options.output (buildBridge defaultBridge) agoraTypes
+  writePSTypes (getField @"output" options) (buildBridge defaultBridge) agoraTypes

--- a/agora-specs/Property/Governor.hs
+++ b/agora-specs/Property/Governor.hs
@@ -20,6 +20,7 @@ import Agora.Proposal.Time (
 import Data.Default.Class (Default (def))
 import Data.Tagged (Tagged (Tagged), untag)
 import Data.Universe (Finite (..), Universe (..))
+import Optics.Core (view)
 import Plutarch.Api.V2 (PScriptContext)
 import Plutarch.Builtin (pforgetData)
 import Plutarch.Context (
@@ -88,7 +89,7 @@ governorDatumValidProperty =
   classifiedPropertyNative gen (const []) expected classifier pisGovernorDatumValid
   where
     classifier :: GovernorDatum -> GovernorDatumCases
-    classifier ((.proposalThresholds) -> ProposalThresholds e c v)
+    classifier (view #proposalThresholds -> ProposalThresholds e c v)
       | e < 0 = ExecuteLE0
       | c < 0 = CreateLE0
       | v < 0 = VoteLE0
@@ -201,7 +202,7 @@ governorMintingProperty =
     opaqueToUnit = plam $ \_ -> pconstant ()
 
     actual :: Term s (PScriptContext :--> PUnit)
-    actual = plam $ \sc -> opaqueToUnit #$ governorPolicy governor.gstOutRef # pforgetData (pconstantData ()) # sc
+    actual = plam $ \sc -> opaqueToUnit #$ governorPolicy (getField @"gstOutRef" governor) # pforgetData (pconstantData ()) # sc
 
     classifier :: ScriptContext -> GovernorPolicyCases
     classifier sc

--- a/agora-specs/Sample/Effect/GovernorMutation.hs
+++ b/agora-specs/Sample/Effect/GovernorMutation.hs
@@ -147,7 +147,7 @@ mkEffectTxInfo newGovDatum =
       --
 
       governorOutputDatum' :: GovernorDatum
-      governorOutputDatum' = effectInputDatum'.newDatum
+      governorOutputDatum' = getField @"newDatum" effectInputDatum'
       governorOutputDatum :: Datum
       governorOutputDatum = Datum $ toBuiltinData governorOutputDatum'
       governorOutput :: TxOut

--- a/agora-specs/Sample/Governor/Initialize.hs
+++ b/agora-specs/Sample/Governor/Initialize.hs
@@ -128,11 +128,11 @@ mintGST :: forall b. CombinableBuilder b => Parameters -> b
 mintGST ps = builder
   where
     gstAC =
-      if ps.mintStateTokenWithName
+      if getField @"mintStateTokenWithName" ps
         then AssetClass (govSymbol, "12345")
         else govAssetClass
     gstCount =
-      if ps.mintMoreThanOneStateToken
+      if getField @"mintMoreThanOneStateToken" ps
         then 10
         else 1
     gst = Value.assetClassValue gstAC gstCount
@@ -141,15 +141,15 @@ mintGST ps = builder
 
     governorOutputDatum =
       let th =
-            if ps.datumThresholdsValid
+            if getField @"datumThresholdsValid" ps
               then def
               else invalidProposalThresholds
           trw =
-            if ps.datumMaxTimeRangeWidthValid
+            if getField @"datumMaxTimeRangeWidthValid" ps
               then def
               else invalidMaxTimeRangeWidth
           ptc =
-            if ps.datumTimingConfigValid
+            if getField @"datumTimingConfigValid" ps
               then def
               else invalidProposalTimings
        in validGovernorOutputDatum
@@ -168,7 +168,7 @@ mintGST ps = builder
     ---
 
     witnessBuilder =
-      if ps.presentWitness
+      if getField @"presentWitness" ps
         then
           mconcat
             [ input $
@@ -189,7 +189,7 @@ mintGST ps = builder
 
     govBuilder =
       let datum =
-            if ps.withGovernorDatum
+            if getField @"withGovernorDatum" ps
               then withDatum governorOutputDatum
               else mempty
        in output $
@@ -274,6 +274,6 @@ mkTestCase name ps valid =
   testPolicy
     valid
     name
-    scripts.compiledGovernorPolicy
+    (getField @"compiledGovernorPolicy" scripts)
     ()
     (mkMinting mintGST ps govSymbol)

--- a/agora-specs/Sample/Governor/Mutate.hs
+++ b/agora-specs/Sample/Governor/Mutate.hs
@@ -145,12 +145,12 @@ mkGovernorBuilder ps =
   let gst = Value.assetClassValue govAssetClass 1
       value = sortValue $ gst <> minAda
       gstOutput =
-        if ps.stealGST
+        if getField @"stealGST" ps
           then pubKey $ head pubKeyHashes
           else script govValidatorHash
       withGSTDatum =
         maybe mempty withDatum $
-          mkGovernorOutputDatum ps.governorOutputDatumValidity
+          mkGovernorOutputDatum (getField @"governorOutputDatumValidity" ps)
    in mconcat
         [ input $
             mconcat
@@ -196,11 +196,11 @@ mkGATValue v q =
 
 mkMockEffectBuilder :: forall b. CombinableBuilder b => MockEffectParameters -> b
 mkMockEffectBuilder ps =
-  let mkGATValue' = mkGATValue ps.gatValidity
+  let mkGATValue' = mkGATValue (getField @"gatValidity" ps)
       inputValue = mkGATValue' 1
       outputValue = inputValue <> burnt
       burnt =
-        if ps.burnGAT
+        if getField @"burnGAT" ps
           then mkGATValue' (-1)
           else mempty
    in mconcat
@@ -222,8 +222,8 @@ mkMockEffectBuilder ps =
 mutate :: forall b. CombinableBuilder b => ParameterBundle -> b
 mutate pb =
   mconcat
-    [ mkGovernorBuilder pb.governorParameters
-    , mkMockEffectBuilder pb.mockEffectParameters
+    [ mkGovernorBuilder (getField @"governorParameters" pb)
+    , mkMockEffectBuilder (getField @"mockEffectParameters" pb)
     ]
 
 --------------------------------------------------------------------------------
@@ -234,7 +234,7 @@ mkTestCase name pb (Validity forGov) =
   testValidator
     forGov
     name
-    agoraScripts.compiledGovernorValidator
+    (getField @"compiledGovernorValidator" agoraScripts)
     governorInputDatum
     governorRedeemer
     (mkSpending mutate pb governorRef)

--- a/agora-specs/Sample/Shared.hs
+++ b/agora-specs/Sample/Shared.hs
@@ -69,14 +69,15 @@ import Agora.Proposal.Time (
 import Agora.Scripts qualified as Scripts
 import Agora.Treasury (treasuryValidator)
 import Agora.Utils (
-  CompiledEffect (CompiledEffect),
-  CompiledMintingPolicy (getCompiledMintingPolicy),
-  CompiledValidator (getCompiledValidator),
+  CompiledEffect,
+  compiledEffect,
   validatorHashToTokenName,
  )
 import Data.Coerce (coerce)
 import Data.Default.Class (Default (..))
 import Data.Tagged (Tagged (..))
+import Optics.Core (view)
+import Optics.Optic ((%))
 import Plutarch (Config (..), TracingMode (DetTracing))
 import Plutarch.Api.V2 (
   PValidator,
@@ -147,10 +148,10 @@ gstUTXORef :: TxOutRef
 gstUTXORef = TxOutRef "f28cd7145c24e66fd5bcd2796837aeb19a48a2656e7833c88c62a2d0450bd00d" 0
 
 govPolicy :: MintingPolicy
-govPolicy = agoraScripts.compiledGovernorPolicy.getCompiledMintingPolicy
+govPolicy = view (#compiledGovernorPolicy % #getCompiledMintingPolicy) agoraScripts
 
 govValidator :: Validator
-govValidator = agoraScripts.compiledGovernorValidator.getCompiledValidator
+govValidator = view (#compiledGovernorValidator % #getCompiledValidator) agoraScripts
 
 govSymbol :: CurrencySymbol
 govSymbol = mintingPolicySymbol govPolicy
@@ -223,7 +224,7 @@ proposalStartingTimeFromTimeRange
 proposalStartingTimeFromTimeRange _ = error "Given time range should be finite and closed"
 
 mkEffect :: (PlutusTx.ToData datum) => ClosedTerm PValidator -> CompiledEffect datum
-mkEffect v = CompiledEffect $ mkValidator deterministicTracingConfing v
+mkEffect v = compiledEffect $ mkValidator deterministicTracingConfing v
 
 mkRedeemer :: forall redeemer. PlutusTx.ToData redeemer => redeemer -> Redeemer
 mkRedeemer = Redeemer . toBuiltinData

--- a/agora-specs/Sample/Stake.hs
+++ b/agora-specs/Sample/Stake.hs
@@ -95,7 +95,7 @@ stakeCreationWrongDatum =
   let datum :: Datum
       datum = Datum (toBuiltinData $ StakeDatum 4242424242424242 (PubKeyCredential signer) Nothing []) -- Too much GT
    in ScriptContext
-        { scriptContextTxInfo = stakeCreation.scriptContextTxInfo {txInfoData = AssocMap.fromList [("", datum)]}
+        { scriptContextTxInfo = (getField @"scriptContextTxInfo" stakeCreation) {txInfoData = AssocMap.fromList [("", datum)]}
         , scriptContextPurpose = Minting stakeSymbol
         }
 
@@ -104,7 +104,7 @@ stakeCreationUnsigned :: ScriptContext
 stakeCreationUnsigned =
   ScriptContext
     { scriptContextTxInfo =
-        stakeCreation.scriptContextTxInfo
+        (getField @"scriptContextTxInfo" stakeCreation)
           { txInfoSignatories = []
           }
     , scriptContextPurpose = Minting stakeSymbol
@@ -125,10 +125,10 @@ stakeDepositWithdraw :: DepositWithdrawExample -> ScriptContext
 stakeDepositWithdraw config =
   let st = Value.assetClassValue stakeAssetClass 1 -- Stake ST
       stakeBefore :: StakeDatum
-      stakeBefore = StakeDatum config.startAmount (PubKeyCredential signer) Nothing []
+      stakeBefore = StakeDatum (getField @"startAmount" config) (PubKeyCredential signer) Nothing []
 
       stakeAfter :: StakeDatum
-      stakeAfter = stakeBefore {stakedAmount = stakeBefore.stakedAmount + config.delta}
+      stakeAfter = stakeBefore {stakedAmount = getField @"stakedAmount" stakeBefore + getField @"delta" config}
 
       stakeRef :: TxOutRef
       stakeRef = TxOutRef "0ffef57e30cc604342c738e31e0451593837b313e7bfb94b0922b142782f98e6" 1
@@ -145,7 +145,7 @@ stakeDepositWithdraw config =
                 , withValue
                     ( sortValue $
                         st
-                          <> Value.assetClassValue (untag governor.gtClassRef) (fromDiscrete stakeBefore.stakedAmount)
+                          <> Value.assetClassValue (untag (getField @"gtClassRef" governor)) (fromDiscrete (getField @"stakedAmount" stakeBefore))
                     )
                 , withDatum stakeAfter
                 , withRef stakeRef
@@ -156,7 +156,7 @@ stakeDepositWithdraw config =
                 , withValue
                     ( sortValue $
                         st
-                          <> Value.assetClassValue (untag governor.gtClassRef) (fromDiscrete stakeAfter.stakedAmount)
+                          <> Value.assetClassValue (untag (getField @"gtClassRef" governor)) (fromDiscrete (getField @"stakedAmount" stakeAfter))
                     )
                 , withDatum stakeAfter
                 ]

--- a/agora-specs/Spec/Effect/GovernorMutation.hs
+++ b/agora-specs/Spec/Effect/GovernorMutation.hs
@@ -32,7 +32,7 @@ specs =
           "valid new governor datum"
           [ validatorSucceedsWith
               "governor validator should pass"
-              agoraScripts.compiledGovernorValidator
+              (getField @"compiledGovernorValidator" agoraScripts)
               ( GovernorDatum
                   def
                   (ProposalId 0)
@@ -55,7 +55,7 @@ specs =
           "invalid new governor datum"
           [ validatorFailsWith
               "governor validator should fail"
-              agoraScripts.compiledGovernorValidator
+              (getField @"compiledGovernorValidator" agoraScripts)
               ( GovernorDatum
                   def
                   (ProposalId 0)

--- a/agora-specs/Spec/Proposal.hs
+++ b/agora-specs/Spec/Proposal.hs
@@ -76,7 +76,7 @@ specs =
               map
                 ( \ps ->
                     Create.mkTestTree
-                      (show ps.proposalStatus)
+                      (show (getField @"proposalStatus" ps))
                       ps
                       True
                       False
@@ -105,7 +105,7 @@ specs =
                     map
                       ( \ps ->
                           Cosign.mkTestTree
-                            ("status: " <> show ps.proposalStatus)
+                            ("status: " <> show (getField @"proposalStatus" ps))
                             ps
                             False
                       )
@@ -166,9 +166,9 @@ specs =
                                 mkName b =
                                   unwords
                                     [ "from"
-                                    , show b.proposalParameters.fromStatus
+                                    , show (getField @"fromStatus" (getField @"proposalParameters" b))
                                     , "to"
-                                    , show b.proposalParameters.toStatus
+                                    , show (getField @"toStatus" (getField @"proposalParameters" b))
                                     ]
                              in [ Advance.mkTestTree'
                                     "to next state"
@@ -222,7 +222,7 @@ specs =
                                 }
                           , Advance.mkTestTree'
                               "to next state too late"
-                              (\b -> unwords ["from", show b.proposalParameters.fromStatus])
+                              (\b -> unwords ["from", show (getField @"fromStatus" $ getField @"proposalParameters" b)])
                               (Advance.mkToNextStateTooLateBundles cs es)
                               Advance.Validity
                                 { forProposalValidator = False
@@ -304,7 +304,7 @@ specs =
                   , group "voter: unlock after voting" $
                       map
                         ( \ps ->
-                            let name = show ps.proposalStatus
+                            let name = show (getField @"proposalStatus" ps)
                              in UnlockStake.mkTestTree name ps True
                         )
                         (UnlockStake.mkVoterUnlockStakeAfterVotingParameters nProposals)
@@ -323,10 +323,10 @@ specs =
                             let name =
                                   unwords
                                     [ "role:"
-                                    , show ps.stakeRole
+                                    , show (getField @"stakeRole" ps)
                                     , ","
                                     , "status:"
-                                    , show ps.proposalStatus
+                                    , show (getField @"proposalStatus" ps)
                                     ]
                              in UnlockStake.mkTestTree name ps False
                         )
@@ -337,9 +337,9 @@ specs =
                             let name =
                                   unwords
                                     [ "status:"
-                                    , show ps.proposalStatus
+                                    , show (getField @"proposalStatus" ps)
                                     , "retract votes:"
-                                    , show ps.retractVotes
+                                    , show (getField @"retractVotes" ps)
                                     ]
                              in UnlockStake.mkTestTree name ps False
                         )
@@ -349,7 +349,7 @@ specs =
                         ( \ps ->
                             let name =
                                   unwords
-                                    ["status:", show ps.proposalStatus]
+                                    ["status:", show (getField @"proposalStatus" ps)]
                              in UnlockStake.mkTestTree name ps False
                         )
                         (UnlockStake.mkRemoveCreatorLockBeforeFinishedParameters nProposals)
@@ -363,10 +363,10 @@ specs =
                             let name =
                                   unwords
                                     [ "role:"
-                                    , show ps.stakeRole
+                                    , show (getField @"stakeRole" ps)
                                     , ","
                                     , "status:"
-                                    , show ps.proposalStatus
+                                    , show (getField @"proposalStatus" ps)
                                     ]
                              in UnlockStake.mkTestTree name ps False
                         )

--- a/agora-specs/Spec/Stake.hs
+++ b/agora-specs/Spec/Stake.hs
@@ -16,6 +16,7 @@ import Agora.Stake (
  )
 import Data.Bool (Bool (..))
 import Data.Maybe (Maybe (..))
+import GHC.Records (getField)
 import PlutusLedgerApi.V1 (Credential (PubKeyCredential))
 import Sample.Shared (agoraScripts)
 import Sample.Stake (
@@ -50,17 +51,17 @@ specs =
       "policy"
       [ policySucceedsWith
           "stakeCreation"
-          agoraScripts.compiledStakePolicy
+          (getField @"compiledStakePolicy" agoraScripts)
           ()
           Stake.stakeCreation
       , policyFailsWith
           "stakeCreationWrongDatum"
-          agoraScripts.compiledStakePolicy
+          (getField @"compiledStakePolicy" agoraScripts)
           ()
           Stake.stakeCreationWrongDatum
       , policyFailsWith
           "stakeCreationUnsigned"
-          agoraScripts.compiledStakePolicy
+          (getField @"compiledStakePolicy" agoraScripts)
           ()
           Stake.stakeCreationUnsigned
       ]
@@ -68,19 +69,19 @@ specs =
       "validator"
       [ validatorSucceedsWith
           "stakeDepositWithdraw deposit"
-          agoraScripts.compiledStakeValidator
+          (getField @"compiledStakeValidator" agoraScripts)
           (StakeDatum 100_000 (PubKeyCredential signer) Nothing [])
           (DepositWithdraw 100_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = 100_000})
       , validatorSucceedsWith
           "stakeDepositWithdraw withdraw"
-          agoraScripts.compiledStakeValidator
+          (getField @"compiledStakeValidator" agoraScripts)
           (StakeDatum 100_000 (PubKeyCredential signer) Nothing [])
           (DepositWithdraw $ negate 100_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = negate 100_000})
       , validatorFailsWith
           "stakeDepositWithdraw negative GT"
-          agoraScripts.compiledStakeValidator
+          (getField @"compiledStakeValidator" agoraScripts)
           (StakeDatum 100_000 (PubKeyCredential signer) Nothing [])
           (DepositWithdraw 1_000_000)
           (Stake.stakeDepositWithdraw $ DepositWithdrawExample {startAmount = 100_000, delta = negate 1_000_000})

--- a/agora-specs/Spec/Treasury.hs
+++ b/agora-specs/Spec/Treasury.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 {- |
 Module: Spec.Treasury
 Description: Tests for Agora treasury.
@@ -117,7 +115,7 @@ specs =
               ()
               validCtx
                 { scriptContextTxInfo =
-                    validCtx.scriptContextTxInfo
+                    (getField @"scriptContextTxInfo" validCtx)
                       { txInfoMint =
                           Value.singleton
                             gatCs
@@ -130,8 +128,8 @@ specs =
               compiledTreasuryValidator
               ()
               ()
-              ( let txInfo = validCtx.scriptContextTxInfo
-                    inputs = txInfo.txInfoInputs
+              ( let txInfo = getField @"scriptContextTxInfo" validCtx
+                    inputs = getField @"txInfoInputs" txInfo
                     newInputs =
                       [ head inputs
                       , walletIn

--- a/agora-testlib/Test/Specification.hs
+++ b/agora-testlib/Test/Specification.hs
@@ -57,6 +57,7 @@ import Agora.Utils (
 import Control.Composition ((.**), (.***))
 import Data.Coerce (coerce)
 import Data.Text qualified as Text
+import Optics.Core (view)
 import Plutarch.Evaluate (evalScript)
 import PlutusLedgerApi.V1.Scripts (
   Context (..),
@@ -198,7 +199,7 @@ applyMintingPolicy' ::
 applyMintingPolicy' policy redeemer scriptContext =
   applyMintingPolicyScript
     (mkContext scriptContext)
-    policy.getCompiledMintingPolicy
+    (view #getCompiledMintingPolicy policy)
     (mkRedeemer redeemer)
 
 applyValidator' ::
@@ -213,7 +214,7 @@ applyValidator' ::
 applyValidator' validator datum redeemer scriptContext =
   applyValidator
     (mkContext scriptContext)
-    validator.getCompiledValidator
+    (view #getCompiledValidator validator)
     (mkDatum datum)
     (mkRedeemer redeemer)
 

--- a/agora.cabal
+++ b/agora.cabal
@@ -82,7 +82,6 @@ common lang
     UndecidableInstances
     ViewPatterns
     NoFieldSelectors
-    OverloadedRecordDot
 
   default-language:   Haskell2010
 
@@ -102,6 +101,8 @@ common deps
     , data-default-class
     , generics-sop
     , liqwid-plutarch-extra
+    , optics-core
+    , optics-th
     , plutarch
     , plutarch-extra
     , plutarch-numeric

--- a/agora/Agora/Aeson/Orphans.hs
+++ b/agora/Agora/Aeson/Orphans.hs
@@ -1,6 +1,7 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Agora.Aeson.Orphans (AsBase16Bytes (..)) where
+module Agora.Aeson.Orphans (AsBase16Codec (..), AsBase16Bytes (..)) where
 
 --------------------------------------------------------------------------------
 
@@ -15,9 +16,11 @@ import Data.Aeson.Types qualified as Aeson
 import Data.ByteString.Lazy qualified as Lazy
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Optics.TH (makeFieldLabelsNoPrefix)
 
 --------------------------------------------------------------------------------
 
+import Optics.Core (view)
 import PlutusLedgerApi.V1 qualified as Plutus
 import PlutusLedgerApi.V1.Bytes qualified as Plutus
 import PlutusLedgerApi.V1.Scripts qualified as Plutus
@@ -26,7 +29,12 @@ import PlutusLedgerApi.V1.Value qualified as Plutus
 --------------------------------------------------------------------------------
 
 newtype AsBase16Bytes a = AsBase16Bytes {unAsBase16Bytes :: a}
+
+makeFieldLabelsNoPrefix ''AsBase16Bytes
+
 newtype AsBase16Codec a = AsBase16Codec {unAsBase16Codec :: a}
+
+makeFieldLabelsNoPrefix ''AsBase16Codec
 
 deriving via
   (Plutus.CurrencySymbol, Plutus.TokenName)
@@ -68,7 +76,7 @@ instance (Codec.Serialise a) => Aeson.ToJSON (AsBase16Codec a) where
       . Plutus.encodeByteString
       . Lazy.toStrict
       . Codec.serialise @a
-      . (.unAsBase16Codec)
+      . view #unAsBase16Codec
 
 instance (Codec.Serialise a) => Aeson.FromJSON (AsBase16Codec a) where
   parseJSON v =

--- a/agora/Agora/Bootstrap.hs
+++ b/agora/Agora/Bootstrap.hs
@@ -38,7 +38,7 @@ agoraScripts conf gov = scripts
     mkMintingPolicy' = mkMintingPolicy conf
     mkValidator' = mkValidator conf
 
-    compiledGovernorPolicy = mkMintingPolicy' $ governorPolicy gov.gstOutRef
+    compiledGovernorPolicy = mkMintingPolicy' $ governorPolicy (getField @"gstOutRef" gov)
     compiledGovernorValidator = mkValidator' $ governorValidator scripts
     governorSymbol = mintingPolicySymbol compiledGovernorPolicy
     governorAssetClass = AssetClass (governorSymbol, "")
@@ -48,10 +48,10 @@ agoraScripts conf gov = scripts
     authorityTokenSymbol = mintingPolicySymbol compiledAuthorityPolicy
 
     compiledProposalPolicy = mkMintingPolicy' $ proposalPolicy governorAssetClass
-    compiledProposalValidator = mkValidator' $ proposalValidator scripts gov.maximumCosigners
+    compiledProposalValidator = mkValidator' $ proposalValidator scripts (getField @"maximumCosigners" gov)
 
-    compiledStakePolicy = mkMintingPolicy' $ stakePolicy gov.gtClassRef
-    compiledStakeValidator = mkValidator' $ stakeValidator scripts gov.gtClassRef
+    compiledStakePolicy = mkMintingPolicy' $ stakePolicy (getField @"gtClassRef" gov)
+    compiledStakeValidator = mkValidator' $ stakeValidator scripts (getField @"gtClassRef" gov)
 
     compiledTreasuryValidator = mkValidator' $ treasuryValidator authorityTokenSymbol
 

--- a/agora/Agora/Credential.hs
+++ b/agora/Agora/Credential.hs
@@ -53,7 +53,7 @@ authorizationContext ::
   r ->
   Term s PAuthorizationContext
 authorizationContext f =
-  pcon (PAuthorizationContext f.signatories f.inputs)
+  pcon (PAuthorizationContext (getField @"signatories" f) (getField @"inputs" f))
 
 {- | Check for authorization by credential.
 
@@ -66,7 +66,7 @@ pauthorizedBy = phoistAcyclic $
     pure $
       pmatch credential $ \case
         PPubKeyCredential ((pfield @"_0" #) -> pk) ->
-          ptxSignedBy # ctxF.signatories # pk
+          ptxSignedBy # getField @"signatories" ctxF # pk
         PScriptCredential ((pfield @"_0" #) -> _) ->
           pany
             # plam
@@ -74,4 +74,4 @@ pauthorizedBy = phoistAcyclic $
                   (pfield @"credential" #$ pfield @"address" #$ pfield @"resolved" # input)
                     #== credential
               )
-            # ctxF.inputs
+            # getField @"inputs" ctxF

--- a/agora/Agora/Effect.hs
+++ b/agora/Agora/Effect.hs
@@ -60,14 +60,14 @@ makeEffect gatCs' f =
     -- - In the case of GATs which get _referenced_, this script
     --   won't be run at all, in which case. The auth check needs
     --   to be especially written with that in mind.
-    PSpending txOutRef <- pmatchC $ pfromData ctx.purpose
+    PSpending txOutRef <- pmatchC $ pfromData (getField @"purpose" ctx)
     txOutRef' <- pletC (pfield @"_0" # txOutRef)
 
-    txInfo <- pletFieldsC @'["mint", "inputs"] ctx.txInfo
+    txInfo <- pletFieldsC @'["mint", "inputs"] (getField @"txInfo" ctx)
     gatCs <- pletC $ pconstant gatCs'
 
     pguardC "A single authority token has been burned" $
-      singleAuthorityTokenBurned gatCs txInfo.inputs txInfo.mint
+      singleAuthorityTokenBurned gatCs (getField @"inputs" txInfo) (getField @"mint" txInfo)
 
     -- run effect function
-    pure $ f gatCs datum' txOutRef' ctx.txInfo
+    pure $ f gatCs datum' txOutRef' (getField @"txInfo" ctx)

--- a/agora/Agora/Governor.hs
+++ b/agora/Agora/Governor.hs
@@ -263,9 +263,9 @@ pisGovernorDatumValid = phoistAcyclic $
       foldr1
         (#&&)
         [ ptraceIfFalse "thresholds valid" $
-            pisProposalThresholdsValid # pfromData datumF.proposalThresholds
+            pisProposalThresholdsValid # pfromData (getField @"proposalThresholds" datumF)
         , ptraceIfFalse "timings valid" $
-            pisProposalTimingConfigValid # pfromData datumF.proposalTimings
+            pisProposalTimingConfigValid # pfromData (getField @"proposalTimings" datumF)
         , ptraceIfFalse "time range valid" $
-            pisMaxTimeRangeWidthValid # datumF.createProposalTimeRangeMaxWidth
+            pisMaxTimeRangeWidthValid # getField @"createProposalTimeRangeMaxWidth" datumF
         ]

--- a/agora/Agora/Proposal.hs
+++ b/agora/Agora/Proposal.hs
@@ -952,9 +952,9 @@ pisProposalThresholdsValid = phoistAcyclic $
   plam $ \thresholds -> unTermCont $ do
     thresholdsF <- pletAllC thresholds
 
-    PDiscrete execute' <- pmatchC thresholdsF.execute
-    PDiscrete draft' <- pmatchC thresholdsF.create
-    PDiscrete vote' <- pmatchC thresholdsF.vote
+    PDiscrete execute' <- pmatchC (getField @"execute" thresholdsF)
+    PDiscrete draft' <- pmatchC (getField @"create" thresholdsF)
+    PDiscrete vote' <- pmatchC (getField @"vote" thresholdsF)
 
     execute <- pletC $ pextract # execute'
     draft <- pletC $ pextract # draft'

--- a/agora/Agora/Scripts.hs
+++ b/agora/Agora/Scripts.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 {- | Module     : Agora.Scripts
      Maintainer : connor@mlabs.city
      Description: Precompiled core scripts and utilities
@@ -24,10 +26,12 @@ import Agora.Governor (GovernorDatum, GovernorRedeemer)
 import Agora.Proposal (ProposalDatum, ProposalRedeemer)
 import Agora.Stake (StakeDatum, StakeRedeemer)
 import Agora.Utils (
-  CompiledMintingPolicy (getCompiledMintingPolicy),
-  CompiledValidator (getCompiledValidator),
+  CompiledMintingPolicy,
+  CompiledValidator,
   validatorHashToTokenName,
  )
+import Optics.Core (view)
+import Optics.TH (makeFieldLabelsNoPrefix)
 import Plutarch.Api.V2 (mintingPolicySymbol, validatorHash)
 import PlutusLedgerApi.V1.Value (AssetClass (AssetClass))
 import PlutusLedgerApi.V2 (CurrencySymbol, ValidatorHash)
@@ -47,24 +51,28 @@ import PlutusLedgerApi.V2 (CurrencySymbol, ValidatorHash)
 
      @since 0.2.0
 -}
-data AgoraScripts = AgoraScripts
-  { compiledGovernorPolicy :: CompiledMintingPolicy ()
-  , compiledGovernorValidator :: CompiledValidator GovernorDatum GovernorRedeemer
-  , compiledStakePolicy :: CompiledMintingPolicy ()
-  , compiledStakeValidator :: CompiledValidator StakeDatum StakeRedeemer
-  , compiledProposalPolicy :: CompiledMintingPolicy ()
-  , compiledProposalValidator :: CompiledValidator ProposalDatum ProposalRedeemer
-  , compiledTreasuryValidator :: CompiledValidator () ()
-  , compiledAuthorityTokenPolicy :: CompiledMintingPolicy ()
-  , compiledTreasuryWithdrawalEffect :: CompiledValidator () TreasuryWithdrawalDatum
-  }
+data AgoraScripts where
+  AgoraScripts ::
+    { compiledGovernorPolicy :: CompiledMintingPolicy ()
+    , compiledGovernorValidator :: CompiledValidator GovernorDatum GovernorRedeemer
+    , compiledStakePolicy :: CompiledMintingPolicy ()
+    , compiledStakeValidator :: CompiledValidator StakeDatum StakeRedeemer
+    , compiledProposalPolicy :: CompiledMintingPolicy ()
+    , compiledProposalValidator :: CompiledValidator ProposalDatum ProposalRedeemer
+    , compiledTreasuryValidator :: CompiledValidator () ()
+    , compiledAuthorityTokenPolicy :: CompiledMintingPolicy ()
+    , compiledTreasuryWithdrawalEffect :: CompiledValidator () TreasuryWithdrawalDatum
+    } ->
+    AgoraScripts
+
+makeFieldLabelsNoPrefix ''AgoraScripts
 
 {- | Get the currency symbol of the governor state token.
 
      @since 0.2.0
 -}
 governorSTSymbol :: AgoraScripts -> CurrencySymbol
-governorSTSymbol = mintingPolicySymbol . (.getCompiledMintingPolicy) . (.compiledGovernorPolicy)
+governorSTSymbol = mintingPolicySymbol . view #getCompiledMintingPolicy . view #compiledGovernorPolicy
 
 {- | Get the asset class of the governor state token.
 
@@ -78,14 +86,14 @@ governorSTAssetClass as = AssetClass (governorSTSymbol as, "")
      @since 0.2.0
 -}
 governorValidatorHash :: AgoraScripts -> ValidatorHash
-governorValidatorHash = validatorHash . (.getCompiledValidator) . (.compiledGovernorValidator)
+governorValidatorHash = validatorHash . view #getCompiledValidator . view #compiledGovernorValidator
 
 {- | Get the currency symbol of the propsoal state token.
 
      @since 0.2.0
 -}
 proposalSTSymbol :: AgoraScripts -> CurrencySymbol
-proposalSTSymbol as = mintingPolicySymbol $ (.getCompiledMintingPolicy) as.compiledProposalPolicy
+proposalSTSymbol as = mintingPolicySymbol $ view #getCompiledMintingPolicy (getField @"compiledProposalPolicy" as)
 
 {- | Get the asset class of the governor state token.
 
@@ -99,14 +107,14 @@ proposalSTAssetClass as = AssetClass (proposalSTSymbol as, "")
      @since 0.2.0
 -}
 proposalValidatoHash :: AgoraScripts -> ValidatorHash
-proposalValidatoHash = validatorHash . (.getCompiledValidator) . (.compiledProposalValidator)
+proposalValidatoHash = validatorHash . view #getCompiledValidator . view #compiledProposalValidator
 
 {- | Get the script hash of the governor validator.
 
      @since 0.2.0
 -}
 stakeSTSymbol :: AgoraScripts -> CurrencySymbol
-stakeSTSymbol = mintingPolicySymbol . (.getCompiledMintingPolicy) . (.compiledStakePolicy)
+stakeSTSymbol = mintingPolicySymbol . view #getCompiledMintingPolicy . view #compiledStakePolicy
 
 {- | Get the asset class of the stake state token.
 
@@ -125,18 +133,18 @@ stakeSTAssetClass as =
      @since 0.2.0
 -}
 stakeValidatorHash :: AgoraScripts -> ValidatorHash
-stakeValidatorHash = validatorHash . (.getCompiledValidator) . (.compiledStakeValidator)
+stakeValidatorHash = validatorHash . view #getCompiledValidator . view #compiledStakeValidator
 
 {- | Get the currency symbol of the authority token.
 
      @since 0.2.0
 -}
 authorityTokenSymbol :: AgoraScripts -> CurrencySymbol
-authorityTokenSymbol = mintingPolicySymbol . (.getCompiledMintingPolicy) . (.compiledAuthorityTokenPolicy)
+authorityTokenSymbol = mintingPolicySymbol . view #getCompiledMintingPolicy . view #compiledAuthorityTokenPolicy
 
 {- | Get the script hash of the treasury validator.
 
      @since 0.2.0
 -}
 treasuryValidatorHash :: AgoraScripts -> ValidatorHash
-treasuryValidatorHash = validatorHash . (.getCompiledValidator) . (.compiledTreasuryValidator)
+treasuryValidatorHash = validatorHash . view #getCompiledValidator . view #compiledTreasuryValidator

--- a/agora/Agora/Stake.hs
+++ b/agora/Agora/Stake.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE NoFieldSelectors #-}
 
 {- |
 Module     : Agora.Stake
@@ -680,8 +679,8 @@ pgetStakeRole = phoistAcyclic $
                       (pcon PIrrelevant)
                   PVoted lock' -> pletAll lock' $ \lockF ->
                     pif
-                      (lockF.votedOn #== pid)
-                      (pcon $ PVoter lockF.votedFor)
+                      (getField @"votedOn" lockF #== pid)
+                      (pcon $ PVoter (getField @"votedFor" lockF))
                       (pcon PIrrelevant)
              in pcombineStakeRole # thisRole # role
         )

--- a/agora/Agora/Treasury.hs
+++ b/agora/Agora/Treasury.hs
@@ -33,16 +33,16 @@ treasuryValidator gatCs' = plam $ \_ _ ctx' -> unTermCont $ do
   ctx <- pletFieldsC @["txInfo", "purpose"] ctx'
 
   -- Ensure that script is for spending.
-  PSpending _ <- pmatchC ctx.purpose
+  PSpending _ <- pmatchC (getField @"purpose" ctx)
 
   -- Get the minted value from txInfo.
-  txInfo <- pletFieldsC @'["mint", "inputs"] ctx.txInfo
+  txInfo <- pletFieldsC @'["mint", "inputs"] (getField @"txInfo" ctx)
   let mint :: Term _ (PValue _ _)
-      mint = txInfo.mint
+      mint = getField @"mint" txInfo
 
   gatCs <- pletC $ pconstant gatCs'
 
   pguardC "A single authority token has been burned" $
-    singleAuthorityTokenBurned gatCs txInfo.inputs mint
+    singleAuthorityTokenBurned gatCs (getField @"inputs" txInfo) mint
 
   pure . popaque $ pconstant ()

--- a/agora/Agora/Utils.hs
+++ b/agora/Agora/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {- |
 Module     : Agora.Utils
@@ -22,8 +23,10 @@ module Agora.Utils (
   pstringIntercalate,
   punwords,
   pcurrentTimeDuration,
+  compiledEffect,
 ) where
 
+import Optics.TH (makeFieldLabelsNoPrefix)
 import Plutarch.Api.V1 (PPOSIXTime, PTokenName, PValidatorHash)
 import Plutarch.Api.V2 (PScriptHash)
 import "liqwid-plutarch-extra" Plutarch.Extra.TermCont (pmatchC)
@@ -120,6 +123,8 @@ newtype CompiledValidator (datum :: Type) (redeemer :: Type) = CompiledValidator
   { getCompiledValidator :: Validator
   }
 
+makeFieldLabelsNoPrefix ''CompiledValidator
+
 {- | Type-safe wrapper for compiled plutus miting policy.
 
      @since 0.2.0
@@ -128,6 +133,8 @@ newtype CompiledMintingPolicy (redeemer :: Type) = CompiledMintingPolicy
   { getCompiledMintingPolicy :: MintingPolicy
   }
 
+makeFieldLabelsNoPrefix ''CompiledMintingPolicy
+
 {- | Type-safe wrapper for compiled plutus effect.
 
      @since 0.2.0
@@ -135,6 +142,11 @@ newtype CompiledMintingPolicy (redeemer :: Type) = CompiledMintingPolicy
 newtype CompiledEffect (datum :: Type) = CompiledEffect
   { getCompiledEffect :: Validator
   }
+
+compiledEffect :: forall (datum :: Type). Validator -> CompiledEffect datum
+compiledEffect = CompiledEffect
+
+makeFieldLabelsNoPrefix ''CompiledEffect
 
 -- | @since 1.0.0
 plistEqualsBy ::

--- a/flake.lock
+++ b/flake.lock
@@ -11979,17 +11979,17 @@
         "plutarch": "plutarch_15"
       },
       "locked": {
-        "lastModified": 1664028810,
+        "lastModified": 1664220695,
         "narHash": "sha256-thMEO1P/ciHjnMFyL0bla781TG5C/nB5EEtebb3Boik=",
         "owner": "Liqwid-Labs",
         "repo": "plutarch-script-export",
-        "rev": "4f0da58ba67cdcfe5c7d97e6e27dc00dfb71e657",
+        "rev": "eba175e63516a4fed43ceab1826ea6522f28dd0f",
         "type": "github"
       },
       "original": {
         "owner": "Liqwid-Labs",
+        "ref": "main",
         "repo": "plutarch-script-export",
-        "rev": "4f0da58ba67cdcfe5c7d97e6e27dc00dfb71e657",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,6 @@
           "-XTypeApplications"
           "-XImportQualifiedPost"
           "-XPatternSynonyms"
-          "-XOverloadedRecordDot"
         ])
         liqwid-nix.enableLintCheck
         liqwid-nix.enableCabalFormatCheck


### PR DESCRIPTION
Addresses #189 
- [x] Drop uses of `OverloadedRecordDot`. It should be outright banned after this feature is complete.
- [x] Add `optics-core` and `optics-th` dependencies. These are actually already transitively available.
- [ ] Create all the required instances using [`makeFieldLabelsNoPrefix`](https://hoogle.nix.dance/file/nix/store/mifdpn08w7d7lk6h0j6ccidzgj89c75z-optics-th-lib-optics-th-0.4.1-haddock-doc/share/doc/optics-th/html/Optics-TH.html#v:makeFieldLabelsNoPrefix).
- [x] Fix any errors that arise. Without using any fancy combinators besides `(%)` and `(%%)`.