### PR TITLE
Export `alwaysSucceedsPolicy` as a standalone builder

### DIFF
--- a/agora-scripts/Main.hs
+++ b/agora-scripts/Main.hs
@@ -8,13 +8,16 @@
 -}
 module Main (main) where
 
+import Agora.Bootstrap (alwaysSucceedsPolicyRoledScript)
 import Agora.Bootstrap qualified as Bootstrap
 import Agora.Linker (linker)
+import Data.Aeson qualified as Aeson
 import Data.Default (def)
 import Plutarch (Config (Config), TracingMode (DoTracingAndBinds))
 import ScriptExport.Export (exportMain)
 import ScriptExport.Types (
   Builders,
+  insertBuilder,
   insertScriptExportWithLinker,
  )
 
@@ -31,4 +34,9 @@ builders =
             (Config DoTracingAndBinds)
         )
         linker
+    , -- Note: To be compatible with current off-chain setup, we are not using
+      --  static builder here.
+      insertBuilder
+        "alwaysSucceedsPolicy"
+        (const @_ @Aeson.Value alwaysSucceedsPolicyRoledScript)
     ]

--- a/agora/Agora/Bootstrap.hs
+++ b/agora/Agora/Bootstrap.hs
@@ -4,7 +4,7 @@
 
      Initialize a governance system
 -}
-module Agora.Bootstrap (agoraScripts) where
+module Agora.Bootstrap (agoraScripts, alwaysSucceedsPolicyRoledScript) where
 
 import Agora.AuthorityToken (authorityTokenPolicy)
 import Agora.Effect.GovernorMutation (mutateGovernorValidator)
@@ -18,9 +18,10 @@ import Data.Map (fromList)
 import Data.Text (Text, unpack)
 import Plutarch (Config)
 import Plutarch.Api.V2 (PMintingPolicy)
-import Ply (TypedScriptEnvelope)
+import Plutarch.Extra.Compile (mustCompile)
+import Ply (ScriptRole (MintingPolicyRole), TypedScriptEnvelope)
 import Ply.Plutarch.TypedWriter (TypedWriter, mkEnvelope)
-import ScriptExport.ScriptInfo (RawScriptExport (..))
+import ScriptExport.ScriptInfo (RawScriptExport (..), RoledScript (..))
 
 {- | Parameterize core scripts, given the 'Agora.Governor.Governor'
      parameters and plutarch configurations.
@@ -42,10 +43,6 @@ agoraScripts conf =
       , envelope "agora:noOpValidator" noOpValidator
       , envelope "agora:treasuryWithdrawalValidator" treasuryWithdrawalValidator
       , envelope "agora:mutateGovernorValidator" mutateGovernorValidator
-      , -- NOTE(Emily, Jan 3rd 2023): Adding this in here because it's useful for testnet GT.
-        -- In reality, it shouldn't be used by anyone on mainnet, but removing it is not
-        -- productive for off-chain testing.
-        envelope @PMintingPolicy "agora:alwaysSucceedsPolicy" $ plam $ \_ _ -> popaque $ pcon PUnit
       ]
   where
     envelope ::
@@ -55,3 +52,18 @@ agoraScripts conf =
       ClosedTerm pt ->
       (Text, TypedScriptEnvelope)
     envelope d t = (d, either (error . unpack) id $ mkEnvelope conf d t)
+
+{- | A minting policy that always succeeds.
+
+  NOTE(Emily, Jan 3rd 2023): Adding this in here because it's useful for testnet GT.
+    In reality, it shouldn't be used by anyone on mainnet, but removing it is not
+    productive for off-chain testing.
+
+  @since 1.0.0
+-}
+alwaysSucceedsPolicyRoledScript :: RoledScript
+alwaysSucceedsPolicyRoledScript =
+  RoledScript
+    { script = mustCompile @PMintingPolicy $ plam $ \_ _ -> popaque $ pcon PUnit
+    , role = MintingPolicyRole
+    }

--- a/agora/Agora/Linker.hs
+++ b/agora/Agora/Linker.hs
@@ -114,11 +114,6 @@ linker = do
         , Tagged AuthorityTokenTag CurrencySymbol
         ]
       "agora:mutateGovernorValidator"
-  alwaysSucceedsPolicy' <-
-    fetchTS
-      @MintingPolicyRole
-      @'[]
-      "agora:alwaysSucceedsPolicy"
 
   governor <- getParam
 
@@ -185,7 +180,6 @@ linker = do
             , ("agora:noOpValidator", toRoledScript noOpVal')
             , ("agora:treasuryWithdrawalValidator", toRoledScript treaWithdrawalVal')
             , ("agora:mutateGovernorValidator", toRoledScript mutateGovVal')
-            , ("agora:alwaysSucceedsPolicy", toRoledScript alwaysSucceedsPolicy')
             ]
       , information =
           AgoraScriptInfo


### PR DESCRIPTION
We do this to avoid passing mock parameters while initializing the agora system in our off-chain test suites: Because of agora's design, we have to know the asset class of the GT to bootstrap the protocol, meaning that to use `alwaysSucceedsPolicy` as the mock GT script, we have to query the script server with a mock `Governor` before this pr.

Note that this pr effectively reverts the changes made in https://github.com/Liqwid-Labs/agora/commit/dacd52c915ef01e261449ad7cd3c7a0fb61164e2. Sorry for any confusion.

Example request:
```bash
cabal run agora-scripts -- serve 
curl -s -X POST http://127.0.0.1:3939/query-script/alwaysSucceedsPolicy -H 'Content-Type: application/json' \
  -d "{}" # As long as the body is a valid JSON object
```
The response(always the same):
```json
{"cborHex":"4746010000224981","hash":"919d4c2c9455016289341b1a14dedf697687af31751170d56a31466e","rawHex":"46010000224981","role":"MintingPolicyRole"}
```

